### PR TITLE
feat: changed bonsai_database visibility for `BonsaiPersistentDatabase` and `DatabaseKey` access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ mod error;
 /// Definition and basic implementation of an CommitID
 pub mod id;
 
-pub use bonsai_database::BonsaiDatabase;
+pub use bonsai_database::{BonsaiDatabase, DBError};
 pub use error::BonsaiStorageError;
 pub use trie::merkle_tree::{Membership, ProofNode};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ mod error;
 /// Definition and basic implementation of an CommitID
 pub mod id;
 
-pub use bonsai_database::{BonsaiDatabase, DBError, BonsaiPersistentDatabase, DatabaseKey};
+pub use bonsai_database::{BonsaiDatabase, BonsaiPersistentDatabase, DBError, DatabaseKey};
 pub use error::BonsaiStorageError;
 pub use trie::merkle_tree::{Membership, ProofNode};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@ use crate::trie::merkle_tree::MerkleTree;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec::Vec};
 use bitvec::{order::Msb0, slice::BitSlice, vec::BitVec};
-use bonsai_database::{BonsaiPersistentDatabase, DatabaseKey};
 use changes::ChangeBatch;
 use hashbrown::HashMap;
 use key_value_db::KeyValueDB;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod changes;
 mod key_value_db;
 mod trie;
 
-mod bonsai_database;
+pub mod bonsai_database;
 /// All databases already implemented in this crate.
 pub mod databases;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,14 +102,14 @@ mod changes;
 mod key_value_db;
 mod trie;
 
-pub mod bonsai_database;
+mod bonsai_database;
 /// All databases already implemented in this crate.
 pub mod databases;
 mod error;
 /// Definition and basic implementation of an CommitID
 pub mod id;
 
-pub use bonsai_database::{BonsaiDatabase, DBError};
+pub use bonsai_database::{BonsaiDatabase, DBError, BonsaiPersistentDatabase, DatabaseKey};
 pub use error::BonsaiStorageError;
 pub use trie::merkle_tree::{Membership, ProofNode};
 


### PR DESCRIPTION
Just a simple visibility change for `BonsaiPersistentDatabase` and `DatabaseKey` access.