### PR TITLE
fix: :zap: Added latest starknet-types-core release to support Starkh…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.195", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-starknet-types-core = { version = "0.0.11", default-features = false, features = [
+starknet-types-core = { git = "https://github.com/starknet-io/types-rs", branch = "main", default-features = false, features = [
     "hash",
     "parity-scale-codec",
 ] }

--- a/src/id.rs
+++ b/src/id.rs
@@ -11,6 +11,12 @@ pub trait Id: hash::Hash + PartialEq + Eq + PartialOrd + Ord + Debug + Copy + De
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Default)]
 pub struct BasicId(u64);
 
+impl BasicId {
+    pub fn new(id: u64) -> Self {
+        BasicId(id)
+    }
+}
+
 impl Id for BasicId {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_be_bytes().to_vec()


### PR DESCRIPTION
## fix: :zap: Added latest starknet-types-core release to support Starkhash

<img width="1310" alt="Capture d’écran 2024-04-01 à 16 58 18" src="https://github.com/keep-starknet-strange/bonsai-trie/assets/74653697/4d1087f9-80c8-43c3-9929-91b539b2d722">

When testing the bonsai lib in production we face this problem due to the latest release of starknet-types-core not beeing deployed yet. This PR aims to support latest version of starknet-types-core along with a small impl on BasicId to easily retrieve and store commit ids based on `BlockNumber(u64)`

This PR has been tested against the first 500 Starknet mainnet blocks and works perfectly.