### PR TITLE
perf: make binary nodes compute their edges in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.1.0"
 default = ["std", "rocksdb"]
 rocksdb = ["dep:rocksdb"]
 std = ["parity-scale-codec/std", "bitvec/std", "starknet-types-core/std"]
+# internal
+bench = []
 
 [dependencies]
 bitvec = { version = "1", default-features = false, features = ["alloc"] }
@@ -48,4 +50,5 @@ criterion = "0.5.1"
 
 [[bench]]
 name = "storage"
+required-features = ["bench"]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rocksdb = { optional = true, version = "0.21.0", features = [
 ] }
 
 [dev-dependencies]
+pprof = { version = "0.3", features = ["flamegraph"] }
 pathfinder-common = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-common", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
 pathfinder-crypto = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-crypto", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
 pathfinder-merkle-tree = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-merkle-tree", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
@@ -43,3 +44,8 @@ pathfinder-storage = { git = "https://github.com/massalabs/pathfinder.git", pack
 rand = "0.8.5"
 tempfile = "3.8.0"
 rstest = "0.18.2"
+criterion = "0.5.1"
+
+[[bench]]
+name = "storage"
+harness = false

--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ fn main() {
 }
 ```
 
+## Build and run benchmarks
+
+This crate uses `rayon` to parallelize hash computations. As such, results will vary depending on the number of cores of your cpu.
+```
+cargo bench
+```
+
 ## Acknowledgements
 
 - Shout out to [Danno Ferrin](https://github.com/shemnon) and [Karim Taam](https://github.com/matkt) for their work on Bonsai. This project is heavily inspired by their work.

--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -1,0 +1,39 @@
+use criterion::profiler::Profiler;
+use pprof::ProfilerGuard;
+use std::{fs::File, os::raw::c_int, path::Path};
+
+pub struct FlamegraphProfiler<'a> {
+    frequency: c_int,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a> FlamegraphProfiler<'a> {
+    #[allow(dead_code)]
+    pub fn new(frequency: c_int) -> Self {
+        FlamegraphProfiler {
+            frequency,
+            active_profiler: None,
+        }
+    }
+}
+
+impl<'a> Profiler for FlamegraphProfiler<'a> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).unwrap();
+        let flamegraph_path = benchmark_dir.join("flamegraph.svg");
+        let flamegraph_file = File::create(&flamegraph_path)
+            .expect("File system error while creating flamegraph.svg");
+        if let Some(profiler) = self.active_profiler.take() {
+            profiler
+                .report()
+                .build()
+                .unwrap()
+                .flamegraph(flamegraph_file)
+                .expect("Error writing flamegraph");
+        }
+    }
+}

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -1,0 +1,147 @@
+use std::hint::black_box;
+
+use bitvec::vec::BitVec;
+use bonsai_trie::{
+    databases::HashMapDb,
+    id::{BasicId, BasicIdBuilder},
+    BonsaiStorage, BonsaiStorageConfig,
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{prelude::*, thread_rng};
+use starknet_types_core::{
+    felt::Felt,
+    hash::{Pedersen, StarkHash},
+};
+
+mod flamegraph;
+
+fn storage(c: &mut Criterion) {
+    c.bench_function("storage commit", move |b| {
+        let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+        )
+        .unwrap();
+        let mut rng = thread_rng();
+
+        let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+        for _ in 0..1000 {
+            let bitvec = BitVec::from_vec(vec![
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+            ]);
+            bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+        }
+
+        let mut id_builder = BasicIdBuilder::new();
+        b.iter_batched(
+            || bonsai_storage.clone(),
+            |mut bonsai_storage| {
+                bonsai_storage.commit(id_builder.new_id()).unwrap();
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+fn one_update(c: &mut Criterion) {
+    c.bench_function("one update", move |b| {
+        let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+        )
+        .unwrap();
+        let mut rng = thread_rng();
+
+        let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+        for _ in 0..1000 {
+            let bitvec = BitVec::from_vec(vec![
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+            ]);
+            bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+        }
+
+        let mut id_builder = BasicIdBuilder::new();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        b.iter_batched(
+            || bonsai_storage.clone(),
+            |mut bonsai_storage| {
+                let bitvec = BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]);
+                bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+                bonsai_storage.commit(id_builder.new_id()).unwrap();
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+fn five_updates(c: &mut Criterion) {
+    c.bench_function("five updates", move |b| {
+        let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+        )
+        .unwrap();
+        let mut rng = thread_rng();
+
+        let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+        for _ in 0..1000 {
+            let bitvec = BitVec::from_vec(vec![
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+                rng.gen(),
+            ]);
+            bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+        }
+
+        let mut id_builder = BasicIdBuilder::new();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        b.iter_batched(
+            || bonsai_storage.clone(),
+            |mut bonsai_storage| {
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 2, 2, 5, 4, 5]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 3, 5]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 1, 3, 99, 3]), &felt).unwrap();
+                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 6]), &felt).unwrap();
+                bonsai_storage.commit(id_builder.new_id()).unwrap();
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+fn hash(c: &mut Criterion) {
+    c.bench_function("pedersen hash", move |b| {
+        let felt0 =
+            Felt::from_hex("0x100bd6fbfced88ded1b34bd1a55b747ce3a9fde9a914bca75571e4496b56443")
+                .unwrap();
+        let felt1 =
+            Felt::from_hex("0x00a038cda302fedbc4f6117648c6d3faca3cda924cb9c517b46232c6316b152f")
+                .unwrap();
+        b.iter(|| {
+            black_box(Pedersen::hash(&felt0, &felt1));
+        })
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default(); // .with_profiler(flamegraph::FlamegraphProfiler::new(100));
+    targets = storage, one_update, five_updates, hash
+}
+criterion_main!(benches);

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -113,11 +113,21 @@ fn five_updates(c: &mut Criterion) {
         b.iter_batched(
             || bonsai_storage.clone(),
             |mut bonsai_storage| {
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 2, 2, 5, 4, 5]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 3, 5]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 1, 3, 99, 3]), &felt).unwrap();
-                bonsai_storage.insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 6]), &felt).unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 5]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 2, 2, 5, 4, 5]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 3, 5]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 1, 3, 99, 3]), &felt)
+                    .unwrap();
+                bonsai_storage
+                    .insert(&[], &BitVec::from_vec(vec![0, 1, 2, 3, 4, 6]), &felt)
+                    .unwrap();
                 bonsai_storage.commit(id_builder.new_id()).unwrap();
             },
             criterion::BatchSize::LargeInput,

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -15,7 +15,7 @@ pub struct Change {
 }
 
 #[derive(Debug, Default)]
-#[derive(Clone)]
+#[cfg_attr(feature = "bench", derive(Clone))]
 pub struct ChangeBatch(pub(crate) HashMap<TrieKey, Change>);
 
 const KEY_SEPARATOR: u8 = 0x00;
@@ -116,7 +116,7 @@ impl ChangeBatch {
     }
 }
 
-#[derive(Clone)]
+#[cfg_attr(feature = "bench", derive(Clone))]
 pub struct ChangeStore<ID>
 where
     ID: Id,

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -15,6 +15,7 @@ pub struct Change {
 }
 
 #[derive(Debug, Default)]
+#[derive(Clone)]
 pub struct ChangeBatch(pub(crate) HashMap<TrieKey, Change>);
 
 const KEY_SEPARATOR: u8 = 0x00;
@@ -115,6 +116,7 @@ impl ChangeBatch {
     }
 }
 
+#[derive(Clone)]
 pub struct ChangeStore<ID>
 where
     ID: Id,

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Crate Trie <= KeyValueDB => BonsaiDatabase
-#[derive(Clone)]
+#[cfg_attr(feature = "bench", derive(Clone))]
 pub struct KeyValueDB<DB, ID>
 where
     DB: BonsaiDatabase,

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 /// Crate Trie <= KeyValueDB => BonsaiDatabase
+#[derive(Clone)]
 pub struct KeyValueDB<DB, ID>
 where
     DB: BonsaiDatabase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ where
     tries: MerkleTrees<H, DB, ChangeID>,
 }
 
+#[cfg(feature = "bench")]
 impl<ChangeID, DB, H> Clone for BonsaiStorage<ChangeID, DB, H>
 where
     DB: BonsaiDatabase + Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,19 @@ where
     tries: MerkleTrees<H, DB, ChangeID>,
 }
 
+impl<ChangeID, DB, H> Clone for BonsaiStorage<ChangeID, DB, H>
+where
+    DB: BonsaiDatabase + Clone,
+    ChangeID: id::Id,
+    H: StarkHash + Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self {
+            tries: self.tries.clone(),
+        }
+    }
+}
+
 /// Trie root hash type.
 pub type BonsaiTrieHash = Felt;
 

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -71,6 +71,7 @@ pub(crate) struct MerkleTrees<H: StarkHash + Send + Sync, DB: BonsaiDatabase, Co
     pub trees: HashMap<Vec<u8>, MerkleTree<H>>,
 }
 
+#[cfg(feature = "bench")]
 impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase + Clone, CommitID: Id> Clone
     for MerkleTrees<H, DB, CommitID>
 {
@@ -268,6 +269,7 @@ pub struct MerkleTree<H: StarkHash> {
 }
 
 // NB: #[derive(Clone)] does not work because it expands to an impl block which forces H: Clone, which Pedersen/Poseidon aren't.
+#[cfg(feature = "bench")]
 impl<H: StarkHash> Clone for MerkleTree<H> {
     fn clone(&self) -> Self {
         Self {

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::ToString, vec::Vec, vec};
+use alloc::{format, string::ToString, vec, vec::Vec};
 use bitvec::{
     prelude::{BitSlice, BitVec, Msb0},
     view::BitView,

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec, vec};
 use bitvec::{
     prelude::{BitSlice, BitVec, Msb0},
     view::BitView,
@@ -395,13 +395,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         node_handle: &NodeHandle,
     ) -> Result<NodeOrFelt, BonsaiStorageError<DB::DatabaseError>> {
         let node_id = match node_handle {
-            NodeHandle::Hash(hash) => return Ok(NodeOrFelt::Felt(hash.clone())),
+            NodeHandle::Hash(hash) => return Ok(NodeOrFelt::Felt(*hash)),
             NodeHandle::InMemory(root_id) => root_id,
         };
         let node = self
             .storage_nodes
             .0
-            .get(&node_id)
+            .get(node_id)
             .ok_or(BonsaiStorageError::Trie(
                 "Couldn't fetch node in the temporary storage".to_string(),
             ))?;
@@ -427,7 +427,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         use Node::*;
 
         match node {
-            Unresolved(hash) => Ok(hash.clone()),
+            Unresolved(hash) => Ok(*hash),
             Binary(binary) => {
                 // we check if we have one or two changed children
 


### PR DESCRIPTION
Hi :wave: 
I originally opened this PR here: https://github.com/massalabs/bonsai-trie/pull/4 so that I could show it to @AurelienFT until multi trie is merged on this repo

During the commit of a MerkleTree, when we encounter a Binary node, we can compute the hash of both of the edges in parallel. It turns out, this speeds up the crate quite a lot

I also tried optimizing a little bit more: get a bit lower level with a rayon::join_context in a way that allows to reuse the destination array without having to make a new local one if the compute job for the right path did not get stolen
unfortunately it's unclear whether it has any impact on what the benches tell me so it's not included in the pr

it might because the machine I am currently using for benching has high variation in the results, i might reexplore this at some point