### PR TITLE
perf: use smallvec for keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
       - name: Generate test result and coverage report
         run: |
-          cargo test $CARGO_OPTIONS --no-default-features
+          cargo test $CARGO_OPTIONS
       # - name: Upload test results
       #   uses: EnricoMi/publish-unit-test-result-action@v1
       #   with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ pathfinder-common = { git = "https://github.com/massalabs/pathfinder.git", packa
 pathfinder-crypto = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-crypto", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
 pathfinder-merkle-tree = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-merkle-tree", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
 pathfinder-storage = { git = "https://github.com/massalabs/pathfinder.git", package = "pathfinder-storage", rev = "b7b6d76a76ab0e10f92e5f84ce099b5f727cb4db" }
-rand = "0.8.5"
+rand = { version = "0.8.5", features = ["small_rng"] }
 tempfile = "3.8.0"
 rstest = "0.18.2"
 test-log = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 ] }
 hashbrown = "0.14.3"
 log = "0.4.20"
-smallvec = "1.11.2"
 rayon = { version = "1.9.0", optional = true }
+smallvec = { version = "1.11.2", features = ["serde"] }
 
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [
     "derive",

--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -15,6 +15,42 @@ use starknet_types_core::{
 
 mod flamegraph;
 
+fn drop_storage(c: &mut Criterion) {
+    c.bench_function("drop storage", move |b| {
+        b.iter_batched(
+            || {
+                let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
+                    HashMapDb::<BasicId>::default(),
+                    BonsaiStorageConfig::default(),
+                )
+                .unwrap();
+
+                let mut rng = SmallRng::seed_from_u64(42);
+                let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
+                for _ in 0..4000 {
+                    let bitvec = BitVec::from_vec(vec![
+                        rng.gen(),
+                        rng.gen(),
+                        rng.gen(),
+                        rng.gen(),
+                        rng.gen(),
+                        rng.gen(),
+                    ]);
+                    bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
+                }
+
+                let mut id_builder = BasicIdBuilder::new();
+                let id1 = id_builder.new_id();
+                bonsai_storage.commit(id1).unwrap();
+
+                bonsai_storage
+            },
+            std::mem::drop,
+            BatchSize::LargeInput,
+        );
+    });
+}
+
 fn storage_with_insert(c: &mut Criterion) {
     c.bench_function("storage commit with insert", move |b| {
         let mut rng = thread_rng();
@@ -40,7 +76,6 @@ fn storage_with_insert(c: &mut Criterion) {
                     ]);
                     bonsai_storage.insert(&[], &bitvec, &felt).unwrap();
                 }
-
                 // let mut id_builder = BasicIdBuilder::new();
                 // bonsai_storage.commit(id_builder.new_id()).unwrap();
             },
@@ -56,7 +91,7 @@ fn storage(c: &mut Criterion) {
             BonsaiStorageConfig::default(),
         )
         .unwrap();
-        let mut rng = thread_rng();
+        let mut rng = SmallRng::seed_from_u64(42);
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
         for _ in 0..1000 {
@@ -89,7 +124,7 @@ fn one_update(c: &mut Criterion) {
             BonsaiStorageConfig::default(),
         )
         .unwrap();
-        let mut rng = thread_rng();
+        let mut rng = SmallRng::seed_from_u64(42);
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
         for _ in 0..1000 {
@@ -126,7 +161,7 @@ fn five_updates(c: &mut Criterion) {
             BonsaiStorageConfig::default(),
         )
         .unwrap();
-        let mut rng = thread_rng();
+        let mut rng = SmallRng::seed_from_u64(42);
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
         for _ in 0..1000 {
@@ -226,6 +261,6 @@ fn hash(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default(); // .with_profiler(flamegraph::FlamegraphProfiler::new(100));
-    targets = storage, one_update, five_updates, hash, storage_with_insert, multiple_contracts
+    targets = storage, one_update, five_updates, hash, drop_storage, storage_with_insert, multiple_contracts
 }
 criterion_main!(benches);

--- a/src/bonsai_database.rs
+++ b/src/bonsai_database.rs
@@ -1,4 +1,4 @@
-use crate::{id::Id, SByteVec, Vec};
+use crate::{id::Id, ByteVec, Vec};
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -38,14 +38,14 @@ pub trait BonsaiDatabase {
     fn create_batch(&self) -> Self::Batch;
 
     /// Returns the value of the key if it exists
-    fn get(&self, key: &DatabaseKey) -> Result<Option<SByteVec>, Self::DatabaseError>;
+    fn get(&self, key: &DatabaseKey) -> Result<Option<ByteVec>, Self::DatabaseError>;
 
     #[allow(clippy::type_complexity)]
     /// Returns all values with keys that start with the given prefix
     fn get_by_prefix(
         &self,
         prefix: &DatabaseKey,
-    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError>;
+    ) -> Result<Vec<(ByteVec, ByteVec)>, Self::DatabaseError>;
 
     /// Returns true if the key exists
     fn contains(&self, key: &DatabaseKey) -> Result<bool, Self::DatabaseError>;
@@ -57,7 +57,7 @@ pub trait BonsaiDatabase {
         key: &DatabaseKey,
         value: &[u8],
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError>;
+    ) -> Result<Option<ByteVec>, Self::DatabaseError>;
 
     /// Remove a key-value pair, returns the old value if it existed.
     /// If a batch is provided, the change will be written in the batch instead of the database.
@@ -65,7 +65,7 @@ pub trait BonsaiDatabase {
         &mut self,
         key: &DatabaseKey,
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError>;
+    ) -> Result<Option<ByteVec>, Self::DatabaseError>;
 
     /// Remove all keys that start with the given prefix
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError>;

--- a/src/bonsai_database.rs
+++ b/src/bonsai_database.rs
@@ -1,4 +1,4 @@
-use crate::{id::Id, Vec};
+use crate::{id::Id, SByteVec, Vec};
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -38,14 +38,14 @@ pub trait BonsaiDatabase {
     fn create_batch(&self) -> Self::Batch;
 
     /// Returns the value of the key if it exists
-    fn get(&self, key: &DatabaseKey) -> Result<Option<Vec<u8>>, Self::DatabaseError>;
+    fn get(&self, key: &DatabaseKey) -> Result<Option<SByteVec>, Self::DatabaseError>;
 
     #[allow(clippy::type_complexity)]
     /// Returns all values with keys that start with the given prefix
     fn get_by_prefix(
         &self,
         prefix: &DatabaseKey,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::DatabaseError>;
+    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError>;
 
     /// Returns true if the key exists
     fn contains(&self, key: &DatabaseKey) -> Result<bool, Self::DatabaseError>;
@@ -57,7 +57,7 @@ pub trait BonsaiDatabase {
         key: &DatabaseKey,
         value: &[u8],
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError>;
+    ) -> Result<Option<SByteVec>, Self::DatabaseError>;
 
     /// Remove a key-value pair, returns the old value if it existed.
     /// If a batch is provided, the change will be written in the batch instead of the database.
@@ -65,7 +65,7 @@ pub trait BonsaiDatabase {
         &mut self,
         key: &DatabaseKey,
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError>;
+    ) -> Result<Option<SByteVec>, Self::DatabaseError>;
 
     /// Remove all keys that start with the given prefix
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError>;

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -1,4 +1,4 @@
-use crate::{hash_map::Entry, id::Id, trie::TrieKey, HashMap, ByteVec, Vec, VecDeque};
+use crate::{hash_map::Entry, id::Id, trie::TrieKey, ByteVec, HashMap, Vec, VecDeque};
 use core::iter;
 use serde::{Deserialize, Serialize};
 

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -1,11 +1,11 @@
-use crate::{hash_map::Entry, id::Id, trie::TrieKey, HashMap, SByteVec, Vec, VecDeque};
+use crate::{hash_map::Entry, id::Id, trie::TrieKey, HashMap, ByteVec, Vec, VecDeque};
 use core::iter;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Change {
-    pub old_value: Option<SByteVec>,
-    pub new_value: Option<SByteVec>,
+    pub old_value: Option<ByteVec>,
+    pub new_value: Option<ByteVec>,
 }
 
 #[derive(Debug, Default)]
@@ -32,7 +32,7 @@ impl ChangeBatch {
         }
     }
 
-    pub fn serialize<ID: Id>(&self, id: &ID) -> Vec<(SByteVec, &[u8])> {
+    pub fn serialize<ID: Id>(&self, id: &ID) -> Vec<(ByteVec, &[u8])> {
         self.0
             .iter()
             .flat_map(|(change_key, change)| {
@@ -57,7 +57,7 @@ impl ChangeBatch {
             .collect()
     }
 
-    pub fn deserialize<ID: Id>(id: &ID, changes: Vec<(SByteVec, SByteVec)>) -> Self {
+    pub fn deserialize<ID: Id>(id: &ID, changes: Vec<(ByteVec, ByteVec)>) -> Self {
         let id = id.to_bytes();
         let mut change_batch = ChangeBatch(HashMap::new());
         let mut current_change = Change::default();
@@ -93,7 +93,7 @@ impl ChangeBatch {
     }
 }
 
-pub fn key_old_value<ID: Id>(id: &ID, key: &TrieKey) -> SByteVec {
+pub fn key_old_value<ID: Id>(id: &ID, key: &TrieKey) -> ByteVec {
     id.to_bytes()
         .into_iter()
         .chain(iter::once(KEY_SEPARATOR))
@@ -103,7 +103,7 @@ pub fn key_old_value<ID: Id>(id: &ID, key: &TrieKey) -> SByteVec {
         .collect()
 }
 
-pub fn key_new_value<ID: Id>(id: &ID, key: &TrieKey) -> SByteVec {
+pub fn key_new_value<ID: Id>(id: &ID, key: &TrieKey) -> ByteVec {
     id.to_bytes()
         .into_iter()
         .chain(iter::once(KEY_SEPARATOR))

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -1,10 +1,11 @@
-use crate::{hash_map::Entry, id::Id, trie::TrieKey, HashMap, Vec, VecDeque};
+use crate::{hash_map::Entry, id::Id, trie::TrieKey, HashMap, SByteVec, Vec, VecDeque};
+use core::iter;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Change {
-    pub old_value: Option<Vec<u8>>,
-    pub new_value: Option<Vec<u8>>,
+    pub old_value: Option<SByteVec>,
+    pub new_value: Option<SByteVec>,
 }
 
 #[derive(Debug, Default)]
@@ -31,7 +32,7 @@ impl ChangeBatch {
         }
     }
 
-    pub fn serialize<ID: Id>(&self, id: &ID) -> Vec<(Vec<u8>, &[u8])> {
+    pub fn serialize<ID: Id>(&self, id: &ID) -> Vec<(SByteVec, &[u8])> {
         self.0
             .iter()
             .flat_map(|(change_key, change)| {
@@ -56,7 +57,7 @@ impl ChangeBatch {
             .collect()
     }
 
-    pub fn deserialize<ID: Id>(id: &ID, changes: Vec<(Vec<u8>, Vec<u8>)>) -> Self {
+    pub fn deserialize<ID: Id>(id: &ID, changes: Vec<(SByteVec, SByteVec)>) -> Self {
         let id = id.to_bytes();
         let mut change_batch = ChangeBatch(HashMap::new());
         let mut current_change = Change::default();
@@ -69,8 +70,7 @@ impl ChangeBatch {
             let mut key = key.to_vec();
             let change_type = key.pop().unwrap();
             let key_type = key.pop().unwrap();
-            let change_key =
-                TrieKey::from_variant_and_bytes(key_type, key[id.len() + 1..].to_vec());
+            let change_key = TrieKey::from_variant_and_bytes(key_type, key[id.len() + 1..].into());
             if let Some(last_key) = last_key {
                 if last_key != change_key {
                     change_batch.insert_in_place(last_key, current_change);
@@ -93,26 +93,24 @@ impl ChangeBatch {
     }
 }
 
-pub fn key_old_value<ID: Id>(id: &ID, key: &TrieKey) -> Vec<u8> {
-    [
-        id.to_bytes().as_slice(),
-        &[KEY_SEPARATOR],
-        key.as_slice(),
-        &[key.into()],
-        &[OLD_VALUE],
-    ]
-    .concat()
+pub fn key_old_value<ID: Id>(id: &ID, key: &TrieKey) -> SByteVec {
+    id.to_bytes()
+        .into_iter()
+        .chain(iter::once(KEY_SEPARATOR))
+        .chain(key.as_slice().iter().copied())
+        .chain(iter::once(key.into()))
+        .chain(iter::once(OLD_VALUE))
+        .collect()
 }
 
-pub fn key_new_value<ID: Id>(id: &ID, key: &TrieKey) -> Vec<u8> {
-    [
-        id.to_bytes().as_slice(),
-        &[KEY_SEPARATOR],
-        key.as_slice(),
-        &[key.into()],
-        &[NEW_VALUE],
-    ]
-    .concat()
+pub fn key_new_value<ID: Id>(id: &ID, key: &TrieKey) -> SByteVec {
+    id.to_bytes()
+        .into_iter()
+        .chain(iter::once(KEY_SEPARATOR))
+        .chain(key.as_slice().iter().copied())
+        .chain(iter::once(key.into()))
+        .chain(iter::once(NEW_VALUE))
+        .collect()
 }
 
 #[cfg_attr(feature = "bench", derive(Clone))]

--- a/src/databases/hashmap_db.rs
+++ b/src/databases/hashmap_db.rs
@@ -1,4 +1,4 @@
-use crate::SByteVec;
+use crate::ByteVec;
 use crate::{
     bonsai_database::{BonsaiPersistentDatabase, DBError},
     id::Id,
@@ -22,7 +22,7 @@ impl DBError for HashMapDbError {}
 
 #[derive(Clone, Default)]
 pub struct HashMapDb<ID: Id> {
-    db: HashMap<SByteVec, SByteVec>,
+    db: HashMap<ByteVec, ByteVec>,
     snapshots: BTreeMap<ID, HashMapDb<ID>>,
 }
 
@@ -51,14 +51,14 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
     fn get(
         &self,
         key: &crate::bonsai_database::DatabaseKey,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         Ok(self.db.get(key.as_slice()).cloned())
     }
 
     fn get_by_prefix(
         &self,
         prefix: &crate::bonsai_database::DatabaseKey,
-    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError> {
+    ) -> Result<Vec<(ByteVec, ByteVec)>, Self::DatabaseError> {
         let mut result = Vec::new();
         for (key, value) in self.db.iter() {
             if key.starts_with(prefix.as_slice()) {
@@ -73,7 +73,7 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
         key: &crate::bonsai_database::DatabaseKey,
         value: &[u8],
         _batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         Ok(self.db.insert(key.as_slice().into(), value.into()))
     }
 
@@ -81,7 +81,7 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
         &mut self,
         key: &crate::bonsai_database::DatabaseKey,
         _batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         Ok(self.db.remove(key.as_slice()))
     }
 

--- a/src/databases/hashmap_db.rs
+++ b/src/databases/hashmap_db.rs
@@ -1,3 +1,4 @@
+use crate::SByteVec;
 use crate::{
     bonsai_database::{BonsaiPersistentDatabase, DBError},
     id::Id,
@@ -21,7 +22,7 @@ impl DBError for HashMapDbError {}
 
 #[derive(Clone, Default)]
 pub struct HashMapDb<ID: Id> {
-    db: HashMap<Vec<u8>, Vec<u8>>,
+    db: HashMap<SByteVec, SByteVec>,
     snapshots: BTreeMap<ID, HashMapDb<ID>>,
 }
 
@@ -50,14 +51,14 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
     fn get(
         &self,
         key: &crate::bonsai_database::DatabaseKey,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
         Ok(self.db.get(key.as_slice()).cloned())
     }
 
     fn get_by_prefix(
         &self,
         prefix: &crate::bonsai_database::DatabaseKey,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::DatabaseError> {
+    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError> {
         let mut result = Vec::new();
         for (key, value) in self.db.iter() {
             if key.starts_with(prefix.as_slice()) {
@@ -72,15 +73,15 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
         key: &crate::bonsai_database::DatabaseKey,
         value: &[u8],
         _batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
-        Ok(self.db.insert(key.as_slice().to_vec(), value.to_vec()))
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+        Ok(self.db.insert(key.as_slice().into(), value.into()))
     }
 
     fn remove(
         &mut self,
         key: &crate::bonsai_database::DatabaseKey,
         _batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
         Ok(self.db.remove(key.as_slice()))
     }
 

--- a/src/databases/rocks_db.rs
+++ b/src/databases/rocks_db.rs
@@ -14,7 +14,7 @@ use rocksdb::{
 use crate::{
     bonsai_database::{BonsaiDatabase, BonsaiPersistentDatabase, DBError, DatabaseKey},
     id::Id,
-    SByteVec,
+    ByteVec,
 };
 use log::trace;
 
@@ -185,7 +185,7 @@ where
         key: &DatabaseKey,
         value: &[u8],
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Inserting into RocksDB: {:?} {:?}", key, value);
         let handle_cf = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
         let old_value = self.db.get_cf(&handle_cf, key.as_slice())?;
@@ -197,7 +197,7 @@ where
         Ok(old_value.map(Into::into))
     }
 
-    fn get(&self, key: &DatabaseKey) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    fn get(&self, key: &DatabaseKey) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", key);
         let handle = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
         Ok(self.db.get_cf(&handle, key.as_slice())?.map(Into::into))
@@ -206,7 +206,7 @@ where
     fn get_by_prefix(
         &self,
         prefix: &DatabaseKey,
-    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError> {
+    ) -> Result<Vec<(ByteVec, ByteVec)>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", prefix);
         let handle = self.db.cf_handle(prefix.get_cf()).expect(CF_ERROR);
         let iter = self.db.iterator_cf(
@@ -241,7 +241,7 @@ where
         &mut self,
         key: &DatabaseKey,
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Removing from RocksDB: {:?}", key);
         let handle = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
         let old_value = self.db.get_cf(&handle, key.as_slice())?;
@@ -327,7 +327,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         key: &DatabaseKey,
         value: &[u8],
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Inserting into RocksDB: {:?} {:?}", key, value);
         let handle_cf = self.column_families.get(key.get_cf()).expect(CF_ERROR);
         let old_value = self
@@ -341,7 +341,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         Ok(old_value.map(Into::into))
     }
 
-    fn get(&self, key: &DatabaseKey) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    fn get(&self, key: &DatabaseKey) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", key);
         let handle = self.column_families.get(key.get_cf()).expect(CF_ERROR);
         Ok(self
@@ -353,7 +353,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
     fn get_by_prefix(
         &self,
         prefix: &DatabaseKey,
-    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError> {
+    ) -> Result<Vec<(ByteVec, ByteVec)>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", prefix);
         let handle = self.column_families.get(prefix.get_cf()).expect(CF_ERROR);
         let iter = self.txn.iterator_cf(
@@ -388,7 +388,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         &mut self,
         key: &DatabaseKey,
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
+    ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Removing from RocksDB: {:?}", key);
         let handle = self.column_families.get(key.get_cf()).expect(CF_ERROR);
         let old_value = self

--- a/src/databases/rocks_db.rs
+++ b/src/databases/rocks_db.rs
@@ -14,6 +14,7 @@ use rocksdb::{
 use crate::{
     bonsai_database::{BonsaiDatabase, BonsaiPersistentDatabase, DBError, DatabaseKey},
     id::Id,
+    SByteVec,
 };
 use log::trace;
 
@@ -184,7 +185,7 @@ where
         key: &DatabaseKey,
         value: &[u8],
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
         trace!("Inserting into RocksDB: {:?} {:?}", key, value);
         let handle_cf = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
         let old_value = self.db.get_cf(&handle_cf, key.as_slice())?;
@@ -193,19 +194,19 @@ where
         } else {
             self.db.put_cf(&handle_cf, key.as_slice(), value)?;
         }
-        Ok(old_value)
+        Ok(old_value.map(Into::into))
     }
 
-    fn get(&self, key: &DatabaseKey) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    fn get(&self, key: &DatabaseKey) -> Result<Option<SByteVec>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", key);
         let handle = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
-        Ok(self.db.get_cf(&handle, key.as_slice())?)
+        Ok(self.db.get_cf(&handle, key.as_slice())?.map(Into::into))
     }
 
     fn get_by_prefix(
         &self,
         prefix: &DatabaseKey,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::DatabaseError> {
+    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", prefix);
         let handle = self.db.cf_handle(prefix.get_cf()).expect(CF_ERROR);
         let iter = self.db.iterator_cf(
@@ -216,7 +217,7 @@ where
             .map_while(|kv| {
                 if let Ok((key, value)) = kv {
                     if key.starts_with(prefix.as_slice()) {
-                        Some((key.to_vec(), value.to_vec()))
+                        Some(((*key).into(), (*value).into()))
                     } else {
                         None
                     }
@@ -240,7 +241,7 @@ where
         &mut self,
         key: &DatabaseKey,
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
         trace!("Removing from RocksDB: {:?}", key);
         let handle = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
         let old_value = self.db.get_cf(&handle, key.as_slice())?;
@@ -249,7 +250,7 @@ where
         } else {
             self.db.delete_cf(&handle, key.as_slice())?;
         }
-        Ok(old_value)
+        Ok(old_value.map(Into::into))
     }
 
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError> {
@@ -326,7 +327,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         key: &DatabaseKey,
         value: &[u8],
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
         trace!("Inserting into RocksDB: {:?} {:?}", key, value);
         let handle_cf = self.column_families.get(key.get_cf()).expect(CF_ERROR);
         let old_value = self
@@ -337,21 +338,22 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         } else {
             self.txn.put_cf(handle_cf, key.as_slice(), value)?;
         }
-        Ok(old_value)
+        Ok(old_value.map(Into::into))
     }
 
-    fn get(&self, key: &DatabaseKey) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    fn get(&self, key: &DatabaseKey) -> Result<Option<SByteVec>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", key);
         let handle = self.column_families.get(key.get_cf()).expect(CF_ERROR);
         Ok(self
             .txn
-            .get_cf_opt(handle, key.as_slice(), &self.read_options)?)
+            .get_cf_opt(handle, key.as_slice(), &self.read_options)?
+            .map(Into::into))
     }
 
     fn get_by_prefix(
         &self,
         prefix: &DatabaseKey,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::DatabaseError> {
+    ) -> Result<Vec<(SByteVec, SByteVec)>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", prefix);
         let handle = self.column_families.get(prefix.get_cf()).expect(CF_ERROR);
         let iter = self.txn.iterator_cf(
@@ -362,7 +364,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
             .map_while(|kv| {
                 if let Ok((key, value)) = kv {
                     if key.starts_with(prefix.as_slice()) {
-                        Some((key.to_vec(), value.to_vec()))
+                        Some(((*key).into(), (*value).into()))
                     } else {
                         None
                     }
@@ -386,7 +388,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         &mut self,
         key: &DatabaseKey,
         batch: Option<&mut Self::Batch>,
-    ) -> Result<Option<Vec<u8>>, Self::DatabaseError> {
+    ) -> Result<Option<SByteVec>, Self::DatabaseError> {
         trace!("Removing from RocksDB: {:?}", key);
         let handle = self.column_families.get(key.get_cf()).expect(CF_ERROR);
         let old_value = self
@@ -397,7 +399,7 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         } else {
             self.txn.delete_cf(handle, key.as_slice())?;
         }
-        Ok(old_value)
+        Ok(old_value.map(Into::into))
     }
 
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError> {

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,9 +1,9 @@
-use crate::Vec;
+use crate::SByteVec;
 use core::{fmt::Debug, hash};
 
 /// Trait to be implemented on any type that can be used as an ID.
 pub trait Id: hash::Hash + PartialEq + Eq + PartialOrd + Ord + Debug + Copy + Default {
-    fn to_bytes(&self) -> Vec<u8>;
+    fn to_bytes(&self) -> SByteVec;
 }
 
 /// A basic ID type that can be used for testing.
@@ -17,8 +17,8 @@ impl BasicId {
 }
 
 impl Id for BasicId {
-    fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_be_bytes().to_vec()
+    fn to_bytes(&self) -> SByteVec {
+        SByteVec::from(&self.0.to_be_bytes() as &[_])
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,9 +1,9 @@
-use crate::SByteVec;
+use crate::ByteVec;
 use core::{fmt::Debug, hash};
 
 /// Trait to be implemented on any type that can be used as an ID.
 pub trait Id: hash::Hash + PartialEq + Eq + PartialOrd + Ord + Debug + Copy + Default {
-    fn to_bytes(&self) -> SByteVec;
+    fn to_bytes(&self) -> ByteVec;
 }
 
 /// A basic ID type that can be used for testing.
@@ -17,8 +17,8 @@ impl BasicId {
 }
 
 impl Id for BasicId {
-    fn to_bytes(&self) -> SByteVec {
-        SByteVec::from(&self.0.to_be_bytes() as &[_])
+    fn to_bytes(&self) -> ByteVec {
+        ByteVec::from(&self.0.to_be_bytes() as &[_])
     }
 }
 

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -1,6 +1,6 @@
 use crate::{
     changes::key_new_value, format, trie::merkle_tree::bytes_to_bitvec, BTreeSet,
-    Change as ExternChange, SByteVec, ToString,
+    Change as ExternChange, ByteVec, ToString,
 };
 use bitvec::{order::Msb0, vec::BitVec};
 use hashbrown::HashMap;
@@ -165,7 +165,7 @@ where
     pub(crate) fn get(
         &self,
         key: &TrieKey,
-    ) -> Result<Option<SByteVec>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<Option<ByteVec>, BonsaiStorageError<DB::DatabaseError>> {
         trace!("Getting from KeyValueDB: {:?}", key);
         Ok(self.db.get(&key.into())?)
     }
@@ -174,7 +174,7 @@ where
         &self,
         key: &TrieKey,
         id: ID,
-    ) -> Result<Option<SByteVec>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<Option<ByteVec>, BonsaiStorageError<DB::DatabaseError>> {
         trace!("Getting from KeyValueDB: {:?} at ID: {:?}", key, id);
 
         // makes sure given id exists

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -1,6 +1,6 @@
 use crate::{
     changes::key_new_value, format, trie::merkle_tree::bytes_to_bitvec, BTreeSet,
-    Change as ExternChange, ToString, Vec,
+    Change as ExternChange, SByteVec, ToString,
 };
 use bitvec::{order::Msb0, vec::BitVec};
 use hashbrown::HashMap;
@@ -165,7 +165,7 @@ where
     pub(crate) fn get(
         &self,
         key: &TrieKey,
-    ) -> Result<Option<Vec<u8>>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<Option<SByteVec>, BonsaiStorageError<DB::DatabaseError>> {
         trace!("Getting from KeyValueDB: {:?}", key);
         Ok(self.db.get(&key.into())?)
     }
@@ -174,7 +174,7 @@ where
         &self,
         key: &TrieKey,
         id: ID,
-    ) -> Result<Option<Vec<u8>>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<Option<SByteVec>, BonsaiStorageError<DB::DatabaseError>> {
         trace!("Getting from KeyValueDB: {:?} at ID: {:?}", key, id);
 
         // makes sure given id exists
@@ -226,7 +226,7 @@ where
             key.clone(),
             Change {
                 old_value,
-                new_value: Some(value.to_vec()),
+                new_value: Some(value.into()),
             },
         );
         Ok(())

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -1,6 +1,6 @@
 use crate::{
-    changes::key_new_value, format, trie::merkle_tree::bytes_to_bitvec, BTreeSet,
-    Change as ExternChange, ByteVec, ToString,
+    changes::key_new_value, format, trie::merkle_tree::bytes_to_bitvec, BTreeSet, ByteVec,
+    Change as ExternChange, ToString,
 };
 use bitvec::{order::Msb0, vec::BitVec};
 use hashbrown::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub(crate) use std::{
 
 use crate::trie::merkle_tree::MerkleTree;
 
-pub(crate) type SByteVec = smallvec::SmallVec<[u8; 32]>;
+pub type SByteVec = smallvec::SmallVec<[u8; 32]>;
 
 pub(crate) trait EncodeExt: parity_scale_codec::Encode {
     fn encode_sbytevec(&self) -> SByteVec {

--- a/src/trie/merkle_tree.rs
+++ b/src/trie/merkle_tree.rs
@@ -1231,7 +1231,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                                 "Couldn't get node from temp storage".to_string(),
                             ))?;
 
-                    (node_id.clone(), node)
+                    (node_id, node)
                 }
             };
 
@@ -1272,7 +1272,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         path: &Path,
     ) -> Result<Option<Node>, BonsaiStorageError<DB::DatabaseError>> {
         let path: ByteVec = path.into();
-        db.get(&TrieKey::new(&identifier, TrieKeyType::Trie, &path))?
+        db.get(&TrieKey::new(identifier, TrieKeyType::Trie, &path))?
             .map(|node| {
                 Node::decode(&mut node.as_slice()).map_err(|err| {
                     BonsaiStorageError::Trie(format!("Couldn't decode node: {}", err))

--- a/src/trie/path.rs
+++ b/src/trie/path.rs
@@ -1,9 +1,10 @@
 use bitvec::{order::Msb0, vec::BitVec};
+use core::iter;
 use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
 use super::merkle_node::Direction;
 
-use crate::Vec;
+use crate::SByteVec;
 
 #[cfg(all(feature = "std", test))]
 use rstest::rstest;
@@ -103,26 +104,28 @@ impl Path {
     }
 }
 
-/// Convert Path to Vec<u8> can be used, for example, to create keys for the database
-impl From<Path> for Vec<u8> {
+/// Convert Path to SByteVec can be used, for example, to create keys for the database
+impl From<Path> for SByteVec {
     fn from(path: Path) -> Self {
-        let key = if path.0.is_empty() {
-            Vec::new()
+        if path.0.is_empty() {
+            SByteVec::new()
         } else {
-            [&[path.0.len() as u8], path.0.as_raw_slice()].concat()
-        };
-        key
+            iter::once(path.0.len() as u8)
+                .chain(path.0.as_raw_slice().iter().copied())
+                .collect()
+        }
     }
 }
 
-impl From<&Path> for Vec<u8> {
+impl From<&Path> for SByteVec {
     fn from(path: &Path) -> Self {
-        let key = if path.0.is_empty() {
-            Vec::new()
+        if path.0.is_empty() {
+            SByteVec::new()
         } else {
-            [&[path.0.len() as u8], path.0.as_raw_slice()].concat()
-        };
-        key
+            iter::once(path.0.len() as u8)
+                .chain(path.0.as_raw_slice().iter().copied())
+                .collect()
+        }
     }
 }
 

--- a/src/trie/path.rs
+++ b/src/trie/path.rs
@@ -4,7 +4,7 @@ use parity_scale_codec::{Decode, Encode, Error, Input, Output};
 
 use super::merkle_node::Direction;
 
-use crate::SByteVec;
+use crate::ByteVec;
 
 #[cfg(all(feature = "std", test))]
 use rstest::rstest;
@@ -105,10 +105,10 @@ impl Path {
 }
 
 /// Convert Path to SByteVec can be used, for example, to create keys for the database
-impl From<Path> for SByteVec {
+impl From<Path> for ByteVec {
     fn from(path: Path) -> Self {
         if path.0.is_empty() {
-            SByteVec::new()
+            ByteVec::new()
         } else {
             iter::once(path.0.len() as u8)
                 .chain(path.0.as_raw_slice().iter().copied())
@@ -117,10 +117,10 @@ impl From<Path> for SByteVec {
     }
 }
 
-impl From<&Path> for SByteVec {
+impl From<&Path> for ByteVec {
     fn from(path: &Path) -> Self {
         if path.0.is_empty() {
-            SByteVec::new()
+            ByteVec::new()
         } else {
             iter::once(path.0.len() as u8)
                 .chain(path.0.as_raw_slice().iter().copied())

--- a/src/trie/trie_db.rs
+++ b/src/trie/trie_db.rs
@@ -1,12 +1,11 @@
-use crate::bonsai_database::DatabaseKey;
-use crate::Vec;
+use crate::{bonsai_database::DatabaseKey, SByteVec};
 
 /// Key in the database of the different elements that are used in the storage of the trie data.
 /// Use `new` function to create a new key.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) enum TrieKey {
-    Trie(Vec<u8>),
-    Flat(Vec<u8>),
+    Trie(SByteVec),
+    Flat(SByteVec),
 }
 
 pub(crate) enum TrieKeyType {
@@ -34,7 +33,7 @@ impl From<&TrieKey> for u8 {
 
 impl TrieKey {
     pub fn new(identifier: &[u8], key_type: TrieKeyType, key: &[u8]) -> Self {
-        let mut final_key = identifier.to_vec();
+        let mut final_key = SByteVec::from(identifier);
         final_key.extend_from_slice(key);
         match key_type {
             TrieKeyType::Trie => TrieKey::Trie(final_key),
@@ -42,7 +41,7 @@ impl TrieKey {
         }
     }
 
-    pub fn from_variant_and_bytes(variant: u8, bytes: Vec<u8>) -> Self {
+    pub fn from_variant_and_bytes(variant: u8, bytes: SByteVec) -> Self {
         match variant {
             x if x == TrieKeyType::Trie as u8 => TrieKey::Trie(bytes),
             x if x == TrieKeyType::Flat as u8 => TrieKey::Flat(bytes),

--- a/src/trie/trie_db.rs
+++ b/src/trie/trie_db.rs
@@ -1,11 +1,11 @@
-use crate::{bonsai_database::DatabaseKey, SByteVec};
+use crate::{bonsai_database::DatabaseKey, ByteVec};
 
 /// Key in the database of the different elements that are used in the storage of the trie data.
 /// Use `new` function to create a new key.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) enum TrieKey {
-    Trie(SByteVec),
-    Flat(SByteVec),
+    Trie(ByteVec),
+    Flat(ByteVec),
 }
 
 pub(crate) enum TrieKeyType {
@@ -33,7 +33,7 @@ impl From<&TrieKey> for u8 {
 
 impl TrieKey {
     pub fn new(identifier: &[u8], key_type: TrieKeyType, key: &[u8]) -> Self {
-        let mut final_key = SByteVec::from(identifier);
+        let mut final_key = ByteVec::from(identifier);
         final_key.extend_from_slice(key);
         match key_type {
             TrieKeyType::Trie => TrieKey::Trie(final_key),
@@ -41,7 +41,7 @@ impl TrieKey {
         }
     }
 
-    pub fn from_variant_and_bytes(variant: u8, bytes: SByteVec) -> Self {
+    pub fn from_variant_and_bytes(variant: u8, bytes: ByteVec) -> Self {
         match variant {
             x if x == TrieKeyType::Trie as u8 => TrieKey::Trie(bytes),
             x if x == TrieKeyType::Flat as u8 => TrieKey::Flat(bytes),


### PR DESCRIPTION
I have a few things to note here and questions

-> I don't like the SByteVec name, but I don't have a better one
-> do we keep the BonsaiDb api unchanged, with `Vec<u8>`s?
    if we do, we don't have to expose SByteVec to the api at all actually

-> smallvec => maybe just having `type SByteVec = [u8; 32];` would be better but we would have to pad the data in some cases

for background, a standard vec basically a tuple (capacity, len, ptr), a smallvec is (capacity, len, union { inline: [u8; 32], inheap: ptr }) and they know if it's one of the two variants by checking if capacity >= 32
I dont think we would have that much of a difference in perf when fixing N to 32 for every key or even part of the api

-> I have changed some stuff like
```rs
let _: Vec<u8> = [
        id.to_bytes().as_slice(),
        &[KEY_SEPARATOR],
        key.as_slice(),
        &[key.into()],
        &[OLD_VALUE],
    ]
    .concat();
```
to iter based methods
```rs
let _: SByteVec = id.to_bytes().into_iter()
    .chain(iter::once(KEY_SEPARATOR))
    .chain(key.as_slice().iter().copied())
    .chain(iter::once(key.into()))
    .chain(iter::once(OLD_VALUE))
    .collect()
```
That kind of looks bad, using iterators like this for individual bytes may mean this doesn't lower to a bunch of optimized copies
especially as we are using smallvec which is out of std
I don't see it in my profiler, so I assume this is fine and llvm inlines everything correctly but I havent checked the assembly

-> there are still lots of copies when converting bitvecs to smallvecs which could be fixed
Optimizing these is not necessarily worth the effort it just bothers me a little

## Results
![image](https://github.com/keep-starknet-strange/bonsai-trie/assets/16473769/91f7de9f-13b8-4015-a8ae-90f68ffce7aa)
The benches use HashMap db and they are handcrafted, they may not accurately translate to the real world


The drop storage bench is not really relevant for real world, i've just added it because on my profiler it shows libc `free` was actually one of the most time consuming functions of my binary


## Other
There should only be very minor conflicts between this PR and #30 

