### PR TITLE
Expose `Path` as public API

### DIFF
--- a/src/databases/hashmap_db.rs
+++ b/src/databases/hashmap_db.rs
@@ -126,7 +126,10 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
 
 impl<ID: Id> BonsaiPersistentDatabase<ID> for HashMapDb<ID> {
     type DatabaseError = HashMapDbError;
-    type Transaction<'a> = HashMapDb<ID> where ID: 'a;
+    type Transaction<'a>
+        = HashMapDb<ID>
+    where
+        ID: 'a;
     fn snapshot(&mut self, id: ID) {
         self.snapshots.insert(id, self.clone());
     }

--- a/src/databases/rocks_db.rs
+++ b/src/databases/rocks_db.rs
@@ -451,7 +451,10 @@ impl<'db, ID> BonsaiPersistentDatabase<ID> for RocksDB<'db, ID>
 where
     ID: Id,
 {
-    type Transaction<'a> = RocksDBTransaction<'a> where Self: 'a;
+    type Transaction<'a>
+        = RocksDBTransaction<'a>
+    where
+        Self: 'a;
     type DatabaseError = RocksDBError;
 
     fn snapshot(&mut self, id: ID) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub mod id;
 
 pub use bonsai_database::{BonsaiDatabase, BonsaiPersistentDatabase, DBError, DatabaseKey};
 pub use error::BonsaiStorageError;
+pub use trie::path::Path;
 pub use trie::proof::{MultiProof, ProofNode};
 
 #[cfg(test)]

--- a/src/trie/mod.rs
+++ b/src/trie/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod iterator;
 mod merkle_node;
-mod path;
+pub(crate) mod path;
 pub(crate) mod proof;
 pub mod tree;
 pub(crate) mod trees;


### PR DESCRIPTION
The `ProofNode` enum is part of the public API, but `Path` is not.

https://github.com/madara-alliance/bonsai-trie/blob/bfc6ad47b3cb8b75b1326bf630ca16e581f194c5/src/trie/proof.rs#L45-L50

https://github.com/madara-alliance/bonsai-trie/blob/bfc6ad47b3cb8b75b1326bf630ca16e581f194c5/src/trie/path.rs#L12-L13
