### PR TITLE
fix(bench): Update benchmarks for new BonsaiStorage::new API

### DIFF
--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use bonsai_trie::{
     databases::HashMapDb,
     id::{BasicId, BasicIdBuilder},
-    BonsaiStorage, BonsaiStorageConfig,
+    BitVec, BonsaiStorage, BonsaiStorageConfig,
 };
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use rand::{prelude::*, thread_rng};
@@ -11,6 +11,9 @@ use starknet_types_core::{
     felt::Felt,
     hash::{Pedersen, Poseidon, StarkHash},
 };
+
+// Key height for benchmarks: 6 bytes = 48 bits
+const BENCH_KEY_HEIGHT: u8 = 48;
 
 mod flamegraph;
 
@@ -21,8 +24,8 @@ fn drop_storage(c: &mut Criterion) {
                 let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
                     HashMapDb::<BasicId>::default(),
                     BonsaiStorageConfig::default(),
-                )
-                .unwrap();
+                    BENCH_KEY_HEIGHT,
+                );
 
                 let mut rng = SmallRng::seed_from_u64(42);
                 let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
@@ -58,8 +61,8 @@ fn storage_with_insert(c: &mut Criterion) {
                 let bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
                     HashMapDb::<BasicId>::default(),
                     BonsaiStorageConfig::default(),
-                )
-                .unwrap();
+                    BENCH_KEY_HEIGHT,
+                );
                 bonsai_storage
             },
             |bonsai_storage| {
@@ -88,8 +91,8 @@ fn storage(c: &mut Criterion) {
         let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
             HashMapDb::<BasicId>::default(),
             BonsaiStorageConfig::default(),
-        )
-        .unwrap();
+            BENCH_KEY_HEIGHT,
+        );
         let mut rng = SmallRng::seed_from_u64(42);
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
@@ -121,8 +124,8 @@ fn one_update(c: &mut Criterion) {
         let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
             HashMapDb::<BasicId>::default(),
             BonsaiStorageConfig::default(),
-        )
-        .unwrap();
+            BENCH_KEY_HEIGHT,
+        );
         let mut rng = SmallRng::seed_from_u64(42);
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
@@ -158,8 +161,8 @@ fn five_updates(c: &mut Criterion) {
         let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
             HashMapDb::<BasicId>::default(),
             BonsaiStorageConfig::default(),
-        )
-        .unwrap();
+            BENCH_KEY_HEIGHT,
+        );
         let mut rng = SmallRng::seed_from_u64(42);
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();
@@ -208,8 +211,8 @@ fn multiple_contracts(c: &mut Criterion) {
         let mut bonsai_storage: BonsaiStorage<BasicId, _, Pedersen> = BonsaiStorage::new(
             HashMapDb::<BasicId>::default(),
             BonsaiStorageConfig::default(),
-        )
-        .unwrap();
+            32, // 4 bytes = 32 bits for the key in this benchmark
+        );
         let mut rng = thread_rng();
 
         let felt = Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap();


### PR DESCRIPTION
## Summary
- Fix benchmark compilation by updating to new `BonsaiStorage::new` API
- Add `max_height` parameter to all `BonsaiStorage::new` calls
- Remove `.unwrap()` as `new()` no longer returns `Result`
- Add `BitVec` import and `BENCH_KEY_HEIGHT` constant

## Background
The `BonsaiStorage::new` API was changed to require a `max_height` parameter, but the benchmarks were not updated, causing compilation failures when running `cargo bench`.

## Test plan
- [x] `cargo bench --features "bench std rocksdb"` compiles and runs successfully

---
Generated with [Claude Code](https://claude.com/claude-code)