### PR TITLE
feat: add root_hash_staged() for non-destructive root computation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,15 @@ where
         self.tries.root_hash(identifier)
     }
 
+    /// Compute trie root hash from staged (uncommitted) changes without persisting.
+    /// Falls back to the committed root when there are no pending modifications.
+    pub fn root_hash_staged(
+        &self,
+        identifier: &[u8],
+    ) -> Result<BonsaiTrieHash, BonsaiStorageError<DB::DatabaseError>> {
+        self.tries.root_hash_staged(identifier)
+    }
+
     /// This function must be used with transactional state only.
     /// Similar to `commit` but without optimizations.
     pub fn transactional_commit(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,5 +3,6 @@ mod madara_comparison;
 mod merkle_tree;
 mod proptest;
 mod simple;
+mod staged;
 // mod transactional_state;
 mod trie_log;

--- a/src/tests/staged.rs
+++ b/src/tests/staged.rs
@@ -1,0 +1,227 @@
+#![cfg(all(feature = "std", feature = "rocksdb"))]
+use crate::{
+    databases::{create_rocks_db, RocksDB, RocksDBConfig},
+    id::{BasicId, BasicIdBuilder},
+    BitVec, BonsaiStorage, BonsaiStorageConfig,
+};
+use starknet_types_core::{felt::Felt, hash::Pedersen};
+
+#[test]
+fn staged_root_matches_committed_root() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pair1 = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    let pair2 = (
+        vec![1, 2, 2],
+        Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair1.0.clone()), &pair1.1)
+        .unwrap();
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair2.0.clone()), &pair2.1)
+        .unwrap();
+
+    // Staged root should be computable before commit
+    let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    assert_ne!(staged_root, Felt::ZERO);
+
+    // Commit and get the committed root
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+    assert_eq!(staged_root, committed_root);
+}
+
+#[test]
+fn staged_root_after_incremental_inserts() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    // Commit an initial state
+    let pair1 = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair1.0.clone()), &pair1.1)
+        .unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+    // Insert more data without committing
+    let pair2 = (
+        vec![1, 2, 2],
+        Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair2.0.clone()), &pair2.1)
+        .unwrap();
+
+    // Staged root reflects both pair1 (committed) and pair2 (staged)
+    let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    assert_ne!(staged_root, Felt::ZERO);
+
+    // Commit and verify match
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+    assert_eq!(staged_root, committed_root);
+}
+
+#[test]
+fn staged_root_does_not_mutate_tree() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pair1 = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair1.0.clone()), &pair1.1)
+        .unwrap();
+
+    // Call staged root multiple times — should be idempotent
+    let root1 = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    let root2 = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    assert_eq!(root1, root2);
+
+    // Commit should still work after staged computations
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+    assert_eq!(root1, committed_root);
+}
+
+#[test]
+fn staged_root_on_empty_trie() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let bonsai_storage: BonsaiStorage<BasicId, RocksDB<'_, BasicId>, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+
+    let root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    assert_eq!(root, Felt::ZERO);
+}
+
+#[test]
+fn staged_root_falls_back_to_committed_when_no_changes() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pair1 = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair1.0.clone()), &pair1.1)
+        .unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+    let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+    // No new inserts — staged should return the committed root
+    let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    assert_eq!(staged_root, committed_root);
+}
+
+#[test]
+fn staged_root_with_removal() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pair1 = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    let pair2 = (
+        vec![1, 2, 2],
+        Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair1.0.clone()), &pair1.1)
+        .unwrap();
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair2.0.clone()), &pair2.1)
+        .unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+    // Remove one key without committing
+    bonsai_storage
+        .remove(&identifier, &BitVec::from_vec(pair1.0.clone()))
+        .unwrap();
+
+    let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    assert_ne!(staged_root, Felt::ZERO);
+
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+    assert_eq!(staged_root, committed_root);
+}
+
+#[test]
+fn staged_root_with_multiple_identifiers() {
+    let id_a = vec![0x01];
+    let id_b = vec![0x02];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let val_a = Felt::from_hex("0xaa").unwrap();
+    let val_b = Felt::from_hex("0xbb").unwrap();
+    let key = vec![1, 2, 1];
+
+    bonsai_storage
+        .insert(&id_a, &BitVec::from_vec(key.clone()), &val_a)
+        .unwrap();
+    bonsai_storage
+        .insert(&id_b, &BitVec::from_vec(key.clone()), &val_b)
+        .unwrap();
+
+    let staged_a = bonsai_storage.root_hash_staged(&id_a).unwrap();
+    let staged_b = bonsai_storage.root_hash_staged(&id_b).unwrap();
+    assert_ne!(staged_a, staged_b);
+
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+    let committed_a = bonsai_storage.root_hash(&id_a).unwrap();
+    let committed_b = bonsai_storage.root_hash(&id_b).unwrap();
+
+    assert_eq!(staged_a, committed_a);
+    assert_eq!(staged_b, committed_b);
+}

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -379,6 +379,23 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         Ok(NodeOrFelt::Node(node))
     }
 
+    /// Compute the root hash from staged (uncommitted) in-memory changes without
+    /// persisting anything. If no staged changes exist, falls back to reading the
+    /// committed root from the database.
+    pub(crate) fn root_hash_staged<DB: BonsaiDatabase, ID: Id>(
+        &self,
+        db: &KeyValueDB<DB, ID>,
+    ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        match &self.root_node {
+            Some(RootHandle::Loaded(_)) => {
+                let mut hashes = vec![];
+                self.compute_root_hash::<DB>(&mut hashes)
+            }
+            Some(RootHandle::Empty) => Ok(Felt::ZERO),
+            None => self.root_hash(db),
+        }
+    }
+
     fn compute_root_hash<DB: BonsaiDatabase>(
         &self,
         hashes: &mut Vec<Felt>,

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -131,6 +131,19 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
         }
     }
 
+    /// Compute root hash from staged (uncommitted) changes. Falls back to the
+    /// committed root when the identified tree has no pending modifications.
+    pub(crate) fn root_hash_staged(
+        &self,
+        identifier: &[u8],
+    ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        if let Some(tree) = self.trees.get(identifier) {
+            tree.root_hash_staged(&self.db)
+        } else {
+            MerkleTree::<H>::new(identifier.into(), self.max_height).root_hash(&self.db)
+        }
+    }
+
     pub(crate) fn get_keys(
         &self,
         identifier: &[u8],


### PR DESCRIPTION
## Summary

- Adds `root_hash_staged()` to `BonsaiStorage`, `MerkleTrees`, and `MerkleTree` — computes the trie root hash from staged (uncommitted) in-memory changes **without persisting anything to the database**
- Falls back to the committed root when no pending modifications exist
- Works by calling the existing `compute_root_hash()` (a `&self` method that only reads the in-memory node SlotMap) directly, skipping `commit_subtree()` which is the destructive/persisting step

## Motivation

Madara needs to compute the state root to build a block header and verify the block hash **before** deciding whether to commit the block to disk. Today, `root_hash()` requires a prior `commit()`, which means the trie is already persisted by the time validation can happen. This creates a crash-safety gap: if the node crashes between persisting a bad block and reverting it, the DB is left corrupted.

With `root_hash_staged()`, the flow becomes:
1. Insert state diff into tries (in-memory only)
2. `root_hash_staged()` → get state root → build header → compute block hash
3. Validate block hash
4. **Only if valid**: call `commit()` to persist

If validation fails, drop the trie — zero disk impact.

## Test plan

- [x] `staged_root_matches_committed_root` — staged root equals committed root for same data
- [x] `staged_root_after_incremental_inserts` — works after prior commits with new staged data
- [x] `staged_root_does_not_mutate_tree` — calling it multiple times is idempotent, commit still works after
- [x] `staged_root_on_empty_trie` — returns `Felt::ZERO`
- [x] `staged_root_falls_back_to_committed_when_no_changes` — returns committed root when nothing is staged
- [x] `staged_root_with_removal` — works with key removals
- [x] `staged_root_with_multiple_identifiers` — independent roots per trie identifier
- [x] Full existing test suite passes (53/53)
