### PR TITLE
perf: reuse staged hashes and retain hot trie frontiers

### DIFF
--- a/src/tests/staged.rs
+++ b/src/tests/staged.rs
@@ -11,9 +11,8 @@ fn staged_root_matches_committed_root() {
     let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
-    let config = BonsaiStorageConfig::default();
     let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
     let mut id_builder = BasicIdBuilder::new();
 
     let pair1 = (
@@ -224,4 +223,95 @@ fn staged_root_with_multiple_identifiers() {
 
     assert_eq!(staged_a, committed_a);
     assert_eq!(staged_b, committed_b);
+}
+
+#[test]
+fn staged_root_after_multiple_incremental_commits() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pairs = vec![
+        (
+            vec![1, 2, 1],
+            Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+        ),
+        (
+            vec![1, 2, 2],
+            Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
+        ),
+        (
+            vec![1, 2, 3],
+            Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052f").unwrap(),
+        ),
+    ];
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pairs[0].0.clone()), &pairs[0].1)
+        .unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pairs[1].0.clone()), &pairs[1].1)
+        .unwrap();
+    let staged_round_two = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    assert_eq!(staged_round_two, bonsai_storage.root_hash(&identifier).unwrap());
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pairs[2].0.clone()), &pairs[2].1)
+        .unwrap();
+    let staged_round_three = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let final_root = bonsai_storage.root_hash(&identifier).unwrap();
+    assert_eq!(staged_round_three, final_root);
+
+    let comparison_tempdir = tempfile::tempdir().unwrap();
+    let comparison_db = create_rocks_db(comparison_tempdir.path()).unwrap();
+    let mut comparison_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(
+            RocksDB::new(&comparison_db, RocksDBConfig::default()),
+            BonsaiStorageConfig::default(),
+            24,
+        );
+    let mut comparison_ids = BasicIdBuilder::new();
+    for (key, value) in pairs {
+        comparison_storage
+            .insert(&identifier, &BitVec::from_vec(key), &value)
+            .unwrap();
+    }
+    comparison_storage.commit(comparison_ids.new_id()).unwrap();
+
+    assert_eq!(final_root, comparison_storage.root_hash(&identifier).unwrap());
+}
+
+#[test]
+fn clean_commit_with_retained_frontier_is_noop() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pair = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair.0.clone()), &pair.1)
+        .unwrap();
+
+    let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    assert_eq!(staged_root, bonsai_storage.root_hash(&identifier).unwrap());
+
+    // Second commit has no new mutations and should keep the already-loaded frontier stable.
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    assert_eq!(staged_root, bonsai_storage.root_hash(&identifier).unwrap());
+    assert_eq!(staged_root, bonsai_storage.root_hash_staged(&identifier).unwrap());
 }

--- a/src/tests/staged.rs
+++ b/src/tests/staged.rs
@@ -11,8 +11,11 @@ fn staged_root_matches_committed_root() {
     let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
-    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        24,
+    );
     let mut id_builder = BasicIdBuilder::new();
 
     let pair1 = (
@@ -251,19 +254,34 @@ fn staged_root_after_multiple_incremental_commits() {
     ];
 
     bonsai_storage
-        .insert(&identifier, &BitVec::from_vec(pairs[0].0.clone()), &pairs[0].1)
+        .insert(
+            &identifier,
+            &BitVec::from_vec(pairs[0].0.clone()),
+            &pairs[0].1,
+        )
         .unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
 
     bonsai_storage
-        .insert(&identifier, &BitVec::from_vec(pairs[1].0.clone()), &pairs[1].1)
+        .insert(
+            &identifier,
+            &BitVec::from_vec(pairs[1].0.clone()),
+            &pairs[1].1,
+        )
         .unwrap();
     let staged_round_two = bonsai_storage.root_hash_staged(&identifier).unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
-    assert_eq!(staged_round_two, bonsai_storage.root_hash(&identifier).unwrap());
+    assert_eq!(
+        staged_round_two,
+        bonsai_storage.root_hash(&identifier).unwrap()
+    );
 
     bonsai_storage
-        .insert(&identifier, &BitVec::from_vec(pairs[2].0.clone()), &pairs[2].1)
+        .insert(
+            &identifier,
+            &BitVec::from_vec(pairs[2].0.clone()),
+            &pairs[2].1,
+        )
         .unwrap();
     let staged_round_three = bonsai_storage.root_hash_staged(&identifier).unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
@@ -272,12 +290,11 @@ fn staged_root_after_multiple_incremental_commits() {
 
     let comparison_tempdir = tempfile::tempdir().unwrap();
     let comparison_db = create_rocks_db(comparison_tempdir.path()).unwrap();
-    let mut comparison_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(
-            RocksDB::new(&comparison_db, RocksDBConfig::default()),
-            BonsaiStorageConfig::default(),
-            24,
-        );
+    let mut comparison_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&comparison_db, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        24,
+    );
     let mut comparison_ids = BasicIdBuilder::new();
     for (key, value) in pairs {
         comparison_storage
@@ -286,7 +303,10 @@ fn staged_root_after_multiple_incremental_commits() {
     }
     comparison_storage.commit(comparison_ids.new_id()).unwrap();
 
-    assert_eq!(final_root, comparison_storage.root_hash(&identifier).unwrap());
+    assert_eq!(
+        final_root,
+        comparison_storage.root_hash(&identifier).unwrap()
+    );
 }
 
 #[test]
@@ -294,8 +314,11 @@ fn clean_commit_with_retained_frontier_is_noop() {
     let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
-    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        24,
+    );
     let mut id_builder = BasicIdBuilder::new();
 
     let pair = (
@@ -313,5 +336,8 @@ fn clean_commit_with_retained_frontier_is_noop() {
     // Second commit has no new mutations and should keep the already-loaded frontier stable.
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     assert_eq!(staged_root, bonsai_storage.root_hash(&identifier).unwrap());
-    assert_eq!(staged_root, bonsai_storage.root_hash_staged(&identifier).unwrap());
+    assert_eq!(
+        staged_root,
+        bonsai_storage.root_hash_staged(&identifier).unwrap()
+    );
 }

--- a/src/trie/iterator.rs
+++ b/src/trie/iterator.rs
@@ -228,7 +228,7 @@ impl<'a, H: StarkHash + Send + Sync, DB: BonsaiDatabase, ID: Id> MerkleTreeItera
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "rocksdb"))]
 mod tests {
     //! The tree used in this series of tests looks like this:
     //! ```

--- a/src/trie/proof.rs
+++ b/src/trie/proof.rs
@@ -219,7 +219,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "rocksdb"))]
 mod tests {
     use crate::{
         databases::{create_rocks_db, RocksDB, RocksDBConfig},

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -11,7 +11,7 @@ use crate::{
     EncodeExt, HashMap, HashSet, KeyValueDB, ToString, Vec,
 };
 
-use super::iterator::MerkleTreeIterator;
+use super::iterator::{MerkleTreeIterator, NodeVisitor};
 use super::{
     merkle_node::{BinaryNode, Direction, EdgeNode, Node, NodeHandle},
     path::Path,
@@ -48,6 +48,84 @@ pub(crate) enum RootHandle {
     Loaded(NodeKey),
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+struct TreePerfStats {
+    db_node_loads: usize,
+    in_memory_node_hits: usize,
+}
+
+#[derive(Debug)]
+struct StagedHashComputation {
+    root_hash: Felt,
+    hashes: Vec<Felt>,
+}
+
+#[cfg(feature = "std")]
+#[derive(Default)]
+struct StagedHashCacheCell(std::sync::Mutex<Option<StagedHashComputation>>);
+
+#[cfg(feature = "std")]
+impl fmt::Debug for StagedHashCacheCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let has_cached_hashes = self.0.lock().map(|cache| cache.is_some()).unwrap_or(false);
+        f.debug_struct("StagedHashCacheCell")
+            .field("has_cached_hashes", &has_cached_hashes)
+            .finish()
+    }
+}
+
+#[cfg(feature = "std")]
+impl Clone for StagedHashCacheCell {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "std")]
+impl StagedHashCacheCell {
+    fn clear(&self) {
+        if let Ok(mut cache) = self.0.lock() {
+            *cache = None;
+        }
+    }
+
+    fn cached_root_hash(&self) -> Option<Felt> {
+        self.0
+            .lock()
+            .ok()
+            .and_then(|cache| cache.as_ref().map(|cached| cached.root_hash))
+    }
+
+    fn store(&self, computation: StagedHashComputation) {
+        if let Ok(mut cache) = self.0.lock() {
+            *cache = Some(computation);
+        }
+    }
+
+    fn take(&self) -> Option<StagedHashComputation> {
+        self.0.lock().ok().and_then(|mut cache| cache.take())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+#[derive(Default, Debug, Clone)]
+struct StagedHashCacheCell;
+
+#[cfg(not(feature = "std"))]
+impl StagedHashCacheCell {
+    fn clear(&self) {}
+
+    fn cached_root_hash(&self) -> Option<Felt> {
+        None
+    }
+
+    fn store(&self, _computation: StagedHashComputation) {}
+
+    fn take(&self) -> Option<StagedHashComputation> {
+        None
+    }
+}
+
 /// A Starknet binary Merkle-Patricia tree with a specific root entry-point and storage.
 ///
 /// This is used to update, mutate and access global Starknet state as well as individual contract
@@ -65,6 +143,12 @@ pub struct MerkleTree<H: StarkHash> {
     pub(crate) death_row: HashSet<TrieKey>,
     /// The list of leaves that have been modified during the current commit.
     pub(crate) cache_leaf_modified: HashMap<ByteVec, InsertOrRemove<Felt>>,
+    /// Whether this tree has staged mutations that are not yet committed.
+    dirty: bool,
+    /// Cached staged root computation so commit can reuse the exact same hash walk.
+    staged_hashes: StagedHashCacheCell,
+    /// Per-block load counters to show whether the frontier stayed hot.
+    perf_stats: TreePerfStats,
     /// The maximum height of the tree. This is an u8 because we may rely on the fact that it's less than 256 in the future for optimizations.
     pub(crate) max_height: u8,
     /// The hasher used to hash the nodes.
@@ -79,6 +163,9 @@ impl<H: StarkHash> fmt::Debug for MerkleTree<H> {
             .field("identifier", &self.identifier)
             .field("death_row", &self.death_row)
             .field("cache_leaf_modified", &self.cache_leaf_modified)
+            .field("dirty", &self.dirty)
+            .field("staged_hashes", &self.staged_hashes)
+            .field("perf_stats", &self.perf_stats)
             .finish()
     }
 }
@@ -94,6 +181,9 @@ impl<H: StarkHash> Clone for MerkleTree<H> {
             identifier: self.identifier.clone(),
             death_row: self.death_row.clone(),
             cache_leaf_modified: self.cache_leaf_modified.clone(),
+            dirty: self.dirty,
+            staged_hashes: self.staged_hashes.clone(),
+            perf_stats: self.perf_stats,
             _hasher: PhantomData,
         }
     }
@@ -109,6 +199,23 @@ enum NodeOrFelt<'a> {
     Felt(Felt),
 }
 
+struct InvalidateHashesVisitor<H>(PhantomData<H>);
+
+impl<H: StarkHash + Send + Sync> NodeVisitor<H> for InvalidateHashesVisitor<H> {
+    fn visit_node<DB: BonsaiDatabase>(
+        &mut self,
+        tree: &mut MerkleTree<H>,
+        node_id: NodeKey,
+        _prev_height: usize,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        match tree.get_node_mut::<DB>(node_id)? {
+            Node::Binary(binary_node) => binary_node.hash = None,
+            Node::Edge(edge_node) => edge_node.hash = None,
+        }
+        Ok(())
+    }
+}
+
 impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     pub fn new(identifier: ByteVec, max_height: u8) -> Self {
         Self {
@@ -117,9 +224,17 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             identifier,
             death_row: HashSet::new(),
             cache_leaf_modified: HashMap::new(),
+            dirty: false,
+            staged_hashes: Default::default(),
+            perf_stats: Default::default(),
             max_height,
             _hasher: PhantomData,
         }
+    }
+
+    fn mark_dirty(&mut self) {
+        self.dirty = true;
+        self.staged_hashes.clear();
     }
 
     /// Loads the root node or returns None if the tree is empty.
@@ -161,6 +276,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
         let node = db.get(key)?;
         let Some(node) = node else { return Ok(None) };
+        self.perf_stats.db_node_loads += 1;
 
         let node = Node::decode(&mut node.as_slice())?;
         let key = self.nodes.insert(node);
@@ -197,7 +313,10 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 };
                 Ok(node_key)
             }
-            NodeHandle::InMemory(node_key) => Ok(node_key),
+            NodeHandle::InMemory(node_key) => {
+                self.perf_stats.in_memory_node_hits += 1;
+                Ok(node_key)
+            }
         }
     }
 
@@ -292,30 +411,37 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     #[allow(clippy::type_complexity)]
     pub(crate) fn get_updates<DB: BonsaiDatabase>(
         &mut self,
-    ) -> Result<
-        impl Iterator<Item = (TrieKey, InsertOrRemove<ByteVec>)>,
-        BonsaiStorageError<DB::DatabaseError>,
-    > {
+    ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>> {
+        let dirty_before_commit = self.dirty;
         let mut updates = HashMap::new();
         for node_key in mem::take(&mut self.death_row) {
             updates.insert(node_key, InsertOrRemove::Remove);
         }
 
-        if let Some(RootHandle::Loaded(node_id)) = &self.root_node {
-            // compute hashes
-            let mut hashes = vec![];
-            self.compute_root_hash::<DB>(&mut hashes)?;
+        let mut used_staged_hash_cache = false;
+        let mut precomputed_hashes = 0usize;
+        if self.dirty {
+            if let Some(RootHandle::Loaded(node_id)) = self.root_node {
+                let hashes = if let Some(staged) = self.staged_hashes.take() {
+                    used_staged_hash_cache = true;
+                    precomputed_hashes = staged.hashes.len();
+                    staged.hashes
+                } else {
+                    let mut hashes = vec![];
+                    self.compute_root_hash::<DB>(&mut hashes)?;
+                    precomputed_hashes = hashes.len();
+                    hashes
+                };
 
-            // commit the tree
-            self.commit_subtree::<DB>(
-                &mut updates,
-                *node_id,
-                Path::default(),
-                &mut hashes.into_iter(),
-            )?;
+                self.commit_subtree_cached::<DB>(
+                    &mut updates,
+                    node_id,
+                    Path::default(),
+                    &mut hashes.into_iter(),
+                )?;
+            }
+            self.dirty = false;
         }
-
-        self.root_node = None; // unloaded
 
         for (key, value) in mem::take(&mut self.cache_leaf_modified) {
             updates.insert(
@@ -326,10 +452,22 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 },
             );
         }
-        #[cfg(test)]
-        self.assert_empty(); // we should have visited the whole tree
+        log::debug!(
+            "bonsai commit identifier={:?} dirty_before_commit={} used_staged_hash_cache={} precomputed_hashes={} db_node_loads={} in_memory_node_hits={} retained_nodes={} root_loaded={} flat_changes={} trie_updates={}",
+            self.identifier,
+            dirty_before_commit,
+            used_staged_hash_cache,
+            precomputed_hashes,
+            self.perf_stats.db_node_loads,
+            self.perf_stats.in_memory_node_hits,
+            self.nodes.len(),
+            matches!(self.root_node, Some(RootHandle::Loaded(_))),
+            updates.keys().filter(|key| matches!(key, TrieKey::Flat(_))).count(),
+            updates.keys().filter(|key| matches!(key, TrieKey::Trie(_))).count(),
+        );
+        self.perf_stats = Default::default();
 
-        Ok(updates.into_iter())
+        Ok(updates)
     }
 
     // Commit a single merkle tree
@@ -386,10 +524,33 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         &self,
         db: &KeyValueDB<DB, ID>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        if !self.dirty {
+            return self.root_hash(db);
+        }
+
+        if let Some(root_hash) = self.staged_hashes.cached_root_hash() {
+            log::debug!(
+                "bonsai staged root cache hit identifier={:?} retained_nodes={}",
+                self.identifier,
+                self.nodes.len(),
+            );
+            return Ok(root_hash);
+        }
+
         match &self.root_node {
             Some(RootHandle::Loaded(_)) => {
                 let mut hashes = vec![];
-                self.compute_root_hash::<DB>(&mut hashes)
+                let root_hash = self.compute_root_hash::<DB>(&mut hashes)?;
+                log::debug!(
+                    "bonsai staged root computed identifier={:?} precomputed_hashes={} retained_nodes={} db_node_loads={} in_memory_node_hits={}",
+                    self.identifier,
+                    hashes.len(),
+                    self.nodes.len(),
+                    self.perf_stats.db_node_loads,
+                    self.perf_stats.in_memory_node_hits,
+                );
+                self.staged_hashes.store(StagedHashComputation { root_hash, hashes });
+                Ok(root_hash)
             }
             Some(RootHandle::Empty) => Ok(Felt::ZERO),
             None => self.root_hash(db),
@@ -514,60 +675,73 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     /// # Panics
     ///
     /// Panics if the precomputed `hashes` do not match the length of the modified subtree.
-    fn commit_subtree<DB: BonsaiDatabase>(
+    fn commit_subtree_cached<DB: BonsaiDatabase>(
         &mut self,
         updates: &mut HashMap<TrieKey, InsertOrRemove<ByteVec>>,
         node_id: NodeKey,
         path: Path,
         hashes: &mut impl Iterator<Item = Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
-        match self.nodes.remove(node_id).ok_or(BonsaiStorageError::Trie(
+        match self.nodes.get(node_id).cloned().ok_or(BonsaiStorageError::Trie(
             "Couldn't fetch node in the temporary storage".to_string(),
         ))? {
-            Node::Binary(mut binary) => {
+            Node::Binary(binary) => {
                 let left_path = path.new_with_direction(Direction::Left);
                 let left_hash = match binary.left {
                     NodeHandle::Hash(left_hash) => left_hash,
                     NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree::<DB>(updates, node_id, left_path, hashes)?
+                        self.commit_subtree_cached::<DB>(updates, node_id, left_path, hashes)?
                     }
                 };
                 let right_path = path.new_with_direction(Direction::Right);
                 let right_hash = match binary.right {
                     NodeHandle::Hash(right_hash) => right_hash,
                     NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree::<DB>(updates, node_id, right_path, hashes)?
+                        self.commit_subtree_cached::<DB>(updates, node_id, right_path, hashes)?
                     }
                 };
 
                 let hash = hashes.next().expect("mismatched hash state");
 
-                binary.hash = Some(hash);
-                binary.left = NodeHandle::Hash(left_hash);
-                binary.right = NodeHandle::Hash(right_hash);
+                match self.get_node_mut::<DB>(node_id)? {
+                    Node::Binary(binary_node) => binary_node.hash = Some(hash),
+                    Node::Edge(_) => unreachable!("node changed type while committing"),
+                }
+
+                let mut persisted_binary = binary;
+                persisted_binary.hash = Some(hash);
+                persisted_binary.left = NodeHandle::Hash(left_hash);
+                persisted_binary.right = NodeHandle::Hash(right_hash);
                 let key_bytes: ByteVec = path.into();
                 updates.insert(
                     TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
-                    InsertOrRemove::Insert(Node::Binary(binary).encode_bytevec()),
+                    InsertOrRemove::Insert(Node::Binary(persisted_binary).encode_bytevec()),
                 );
                 Ok(hash)
             }
-            Node::Edge(mut edge) => {
+            Node::Edge(edge) => {
                 let mut child_path = path.clone();
                 child_path.0.extend(&edge.path.0);
                 let child_hash = match edge.child {
                     NodeHandle::Hash(right_hash) => right_hash,
                     NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree::<DB>(updates, node_id, child_path, hashes)?
+                        self.commit_subtree_cached::<DB>(updates, node_id, child_path, hashes)?
                     }
                 };
                 let hash = hashes.next().expect("mismatched hash state");
-                edge.hash = Some(hash);
-                edge.child = NodeHandle::Hash(child_hash);
+
+                match self.get_node_mut::<DB>(node_id)? {
+                    Node::Edge(edge_node) => edge_node.hash = Some(hash),
+                    Node::Binary(_) => unreachable!("node changed type while committing"),
+                }
+
+                let mut persisted_edge = edge;
+                persisted_edge.hash = Some(hash);
+                persisted_edge.child = NodeHandle::Hash(child_hash);
                 let key_bytes: ByteVec = path.into();
                 updates.insert(
                     TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
-                    InsertOrRemove::Insert(Node::Edge(edge).encode_bytevec()),
+                    InsertOrRemove::Insert(Node::Edge(persisted_edge).encode_bytevec()),
                 );
                 Ok(hash)
             }
@@ -618,8 +792,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             }
         }
 
+        self.mark_dirty();
         let mut iter = self.iter(db);
-        iter.seek_to(key)?;
+        iter.traverse_to(&mut InvalidateHashesVisitor(PhantomData), key)?;
         log::trace!("Iter is {:?}", iter);
         let path_nodes = iter.current_nodes_heights;
 
@@ -825,8 +1000,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
         leaf_entry.insert(InsertOrRemove::Remove);
 
+        self.mark_dirty();
         let mut iter = self.iter(db);
-        iter.seek_to(key)?;
+        iter.traverse_to(&mut InvalidateHashesVisitor(PhantomData), key)?;
         log::trace!("Iter is {:?}", iter);
         let mut path_nodes = iter.current_nodes_heights;
 

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -67,7 +67,7 @@ struct StagedHashCacheCell(std::sync::Mutex<Option<StagedHashComputation>>);
 #[cfg(feature = "std")]
 impl fmt::Debug for StagedHashCacheCell {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let has_cached_hashes = self.0.lock().map(|cache| cache.is_some()).unwrap_or(false);
+        let has_cached_hashes = self.lock_cache().is_some();
         f.debug_struct("StagedHashCacheCell")
             .field("has_cached_hashes", &has_cached_hashes)
             .finish()
@@ -83,27 +83,27 @@ impl Clone for StagedHashCacheCell {
 
 #[cfg(feature = "std")]
 impl StagedHashCacheCell {
+    fn lock_cache(&self) -> std::sync::MutexGuard<'_, Option<StagedHashComputation>> {
+        self.0.lock().unwrap_or_else(|poisoned| {
+            log::warn!("recovering poisoned staged hash cache lock");
+            poisoned.into_inner()
+        })
+    }
+
     fn clear(&self) {
-        if let Ok(mut cache) = self.0.lock() {
-            *cache = None;
-        }
+        *self.lock_cache() = None;
     }
 
     fn cached_root_hash(&self) -> Option<Felt> {
-        self.0
-            .lock()
-            .ok()
-            .and_then(|cache| cache.as_ref().map(|cached| cached.root_hash))
+        self.lock_cache().as_ref().map(|cached| cached.root_hash)
     }
 
     fn store(&self, computation: StagedHashComputation) {
-        if let Ok(mut cache) = self.0.lock() {
-            *cache = Some(computation);
-        }
+        *self.lock_cache() = Some(computation);
     }
 
     fn take(&self) -> Option<StagedHashComputation> {
-        self.0.lock().ok().and_then(|mut cache| cache.take())
+        self.lock_cache().take()
     }
 }
 
@@ -235,6 +235,179 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     fn mark_dirty(&mut self) {
         self.dirty = true;
         self.staged_hashes.clear();
+    }
+
+    fn in_memory_node_hash<DB: BonsaiDatabase>(
+        &self,
+        node_id: NodeKey,
+    ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        self.nodes
+            .get(node_id)
+            .and_then(Node::get_hash)
+            .ok_or_else(|| {
+                BonsaiStorageError::Trie(format!(
+                    "missing committed hash for retained node {node_id:?}"
+                ))
+            })
+    }
+
+    fn mark_recent_frontier_nodes<DB: BonsaiDatabase>(
+        &self,
+        retained_nodes: &mut HashSet<NodeKey>,
+        node_id: NodeKey,
+        key: &BitSlice,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let node = self.nodes.get(node_id).ok_or_else(|| {
+            BonsaiStorageError::Trie(format!("Dangling in-memory node key: {node_id:?}"))
+        })?;
+        retained_nodes.insert(node_id);
+
+        match node {
+            Node::Binary(binary) => {
+                let height = binary.height as usize;
+                if height >= key.len() {
+                    return Ok(());
+                }
+
+                if let NodeHandle::InMemory(child_id) =
+                    binary.get_child(Direction::from(key[height]))
+                {
+                    self.mark_recent_frontier_nodes::<DB>(retained_nodes, child_id, key)?;
+                }
+            }
+            Node::Edge(edge) => {
+                let height = edge.height as usize;
+                if height >= key.len() {
+                    return Ok(());
+                }
+
+                let key_suffix = &key[height..];
+                let common_len = key_suffix
+                    .iter()
+                    .zip(edge.path.0.iter())
+                    .take_while(|(lhs, rhs)| lhs == rhs)
+                    .count();
+                if common_len != edge.path.len() {
+                    return Ok(());
+                }
+
+                if let NodeHandle::InMemory(child_id) = edge.child {
+                    self.mark_recent_frontier_nodes::<DB>(retained_nodes, child_id, key)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn retain_child_handle<DB: BonsaiDatabase>(
+        &self,
+        handle: NodeHandle,
+        retained_nodes: &HashSet<NodeKey>,
+        remapped_nodes: &mut HashMap<NodeKey, NodeKey>,
+        new_nodes: &mut SlotMap<NodeKey, Node>,
+    ) -> Result<NodeHandle, BonsaiStorageError<DB::DatabaseError>> {
+        match handle {
+            NodeHandle::Hash(hash) => Ok(NodeHandle::Hash(hash)),
+            NodeHandle::InMemory(node_id) if retained_nodes.contains(&node_id) => {
+                Ok(NodeHandle::InMemory(self.rebuild_retained_frontier::<DB>(
+                    node_id,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?))
+            }
+            NodeHandle::InMemory(node_id) => {
+                Ok(NodeHandle::Hash(self.in_memory_node_hash::<DB>(node_id)?))
+            }
+        }
+    }
+
+    fn rebuild_retained_frontier<DB: BonsaiDatabase>(
+        &self,
+        node_id: NodeKey,
+        retained_nodes: &HashSet<NodeKey>,
+        remapped_nodes: &mut HashMap<NodeKey, NodeKey>,
+        new_nodes: &mut SlotMap<NodeKey, Node>,
+    ) -> Result<NodeKey, BonsaiStorageError<DB::DatabaseError>> {
+        if let Some(remapped_id) = remapped_nodes.get(&node_id).copied() {
+            return Ok(remapped_id);
+        }
+
+        let mut node = self.nodes.get(node_id).cloned().ok_or_else(|| {
+            BonsaiStorageError::Trie(format!("Dangling in-memory node key: {node_id:?}"))
+        })?;
+
+        match &mut node {
+            Node::Binary(binary) => {
+                binary.left = self.retain_child_handle::<DB>(
+                    binary.left,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?;
+                binary.right = self.retain_child_handle::<DB>(
+                    binary.right,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?;
+            }
+            Node::Edge(edge) => {
+                edge.child = self.retain_child_handle::<DB>(
+                    edge.child,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?;
+            }
+        }
+
+        let remapped_id = new_nodes.insert(node);
+        remapped_nodes.insert(node_id, remapped_id);
+        Ok(remapped_id)
+    }
+
+    fn retain_recent_frontier<DB: BonsaiDatabase>(
+        &mut self,
+        hot_keys: &[ByteVec],
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let Some(root_handle) = self.root_node else {
+            self.nodes.clear();
+            return Ok(());
+        };
+        let RootHandle::Loaded(root_id) = root_handle else {
+            self.nodes.clear();
+            return Ok(());
+        };
+
+        let retained_before = self.nodes.len();
+        let mut retained_nodes = HashSet::default();
+        retained_nodes.insert(root_id);
+        for key in hot_keys {
+            self.mark_recent_frontier_nodes::<DB>(&mut retained_nodes, root_id, hot_key_bits(key))?;
+        }
+
+        let mut remapped_nodes = HashMap::default();
+        let mut new_nodes = SlotMap::default();
+        let new_root = self.rebuild_retained_frontier::<DB>(
+            root_id,
+            &retained_nodes,
+            &mut remapped_nodes,
+            &mut new_nodes,
+        )?;
+
+        self.nodes = new_nodes;
+        self.root_node = Some(RootHandle::Loaded(new_root));
+        log::debug!(
+            "bonsai retained frontier compacted identifier={:?} hot_keys={} retained_before={} retained_after={}",
+            self.identifier,
+            hot_keys.len(),
+            retained_before,
+            self.nodes.len(),
+        );
+
+        Ok(())
     }
 
     /// Loads the root node or returns None if the tree is empty.
@@ -414,6 +587,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>>
     {
         let dirty_before_commit = self.dirty;
+        let hot_keys = self.cache_leaf_modified.keys().cloned().collect::<Vec<_>>();
         let mut updates = HashMap::new();
         for node_key in mem::take(&mut self.death_row) {
             updates.insert(node_key, InsertOrRemove::Remove);
@@ -442,6 +616,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 )?;
             }
             self.dirty = false;
+            self.retain_recent_frontier::<DB>(&hot_keys)?;
         }
 
         for (key, value) in mem::take(&mut self.cache_leaf_modified) {
@@ -769,9 +944,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         if value == Felt::ZERO {
             return self.delete_leaf(db, key);
         }
-        if key.len() != self.max_height as _ {
+        if key.len() != usize::from(self.max_height) {
             return Err(BonsaiStorageError::KeyLength {
-                expected: self.max_height as _,
+                expected: usize::from(self.max_height),
                 got: key.len(),
             });
         }
@@ -967,9 +1142,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         db: &KeyValueDB<DB, ID>,
         key: &BitSlice,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
-        if key.len() != self.max_height as _ {
+        if key.len() != usize::from(self.max_height) {
             return Err(BonsaiStorageError::KeyLength {
-                expected: self.max_height as _,
+                expected: usize::from(self.max_height),
                 got: key.len(),
             });
         }
@@ -1329,4 +1504,123 @@ pub(crate) fn bitslice_to_bytes(bitslice: &BitSlice) -> ByteVec {
 
 pub(crate) fn bytes_to_bitvec(bytes: &[u8]) -> BitVec {
     BitSlice::from_slice(&bytes[1..]).to_bitvec()
+}
+
+fn hot_key_bits(key: &[u8]) -> &BitSlice {
+    let Some((&bit_len, raw_bits)) = key.split_first() else {
+        return BitSlice::empty();
+    };
+    let bits = BitSlice::from_slice(raw_bits);
+    &bits[..usize::from(bit_len).min(bits.len())]
+}
+
+#[cfg(all(test, feature = "std"))]
+mod staged_hash_cache_tests {
+    use super::{Node, NodeHandle, RootHandle, StagedHashCacheCell, StagedHashComputation};
+    use crate::{
+        databases::HashMapDb,
+        id::{BasicId, BasicIdBuilder},
+        BitVec, BonsaiStorage, BonsaiStorageConfig,
+    };
+    use starknet_types_core::felt::Felt;
+    use starknet_types_core::hash::Pedersen;
+
+    fn retained_tree<'a>(
+        storage: &'a BonsaiStorage<BasicId, HashMapDb<BasicId>, Pedersen>,
+        identifier: &'a [u8],
+    ) -> &'a super::MerkleTree<Pedersen> {
+        storage.tries.trees.get(identifier).unwrap()
+    }
+
+    #[test]
+    fn staged_hash_cache_recovers_from_poison() {
+        let cache = StagedHashCacheCell::default();
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cache.0.lock().unwrap();
+            panic!("poison staged hash cache");
+        }));
+
+        cache.store(StagedHashComputation {
+            root_hash: Felt::ONE,
+            hashes: vec![Felt::TWO],
+        });
+        assert_eq!(cache.cached_root_hash(), Some(Felt::ONE));
+        assert_eq!(
+            cache.take().map(|cached| cached.hashes),
+            Some(vec![Felt::TWO])
+        );
+    }
+
+    #[test]
+    fn retained_frontier_prunes_unmodified_branch_after_commit() {
+        let identifier = vec![];
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        bonsai_storage
+            .insert(
+                &identifier,
+                &BitVec::from_vec(vec![0b0000_0000]),
+                &Felt::from_hex("0x11").unwrap(),
+            )
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        bonsai_storage
+            .insert(
+                &identifier,
+                &BitVec::from_vec(vec![0b1000_0000]),
+                &Felt::from_hex("0x22").unwrap(),
+            )
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        let tree = retained_tree(&bonsai_storage, &identifier);
+        let root_id = match tree.root_node {
+            Some(RootHandle::Loaded(root_id)) => root_id,
+            other => panic!("expected loaded root, got {other:?}"),
+        };
+        let root = tree.nodes.get(root_id).unwrap();
+        let Node::Binary(root) = root else {
+            panic!("expected binary root after inserting divergent keys");
+        };
+
+        assert_eq!(tree.nodes.len(), 2);
+        assert!(matches!(root.left, NodeHandle::Hash(_)));
+        assert!(matches!(root.right, NodeHandle::InMemory(_)));
+    }
+
+    #[test]
+    fn retained_frontier_stays_bounded_across_disjoint_commits() {
+        let identifier = vec![];
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        for (key, value) in [
+            (vec![0b0000_0000], Felt::from_hex("0x11").unwrap()),
+            (vec![0b1000_0000], Felt::from_hex("0x22").unwrap()),
+            (vec![0b1100_0000], Felt::from_hex("0x33").unwrap()),
+        ] {
+            bonsai_storage
+                .insert(&identifier, &BitVec::from_vec(key), &value)
+                .unwrap();
+            bonsai_storage.commit(id_builder.new_id()).unwrap();
+        }
+
+        let tree = retained_tree(&bonsai_storage, &identifier);
+        assert!(
+            tree.nodes.len() <= 4,
+            "retained frontier should stay small for a single recently touched branch, got {} nodes",
+            tree.nodes.len()
+        );
+    }
 }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -953,16 +953,6 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         let key_bytes = bitslice_to_bytes(key);
         log::trace!("key_bytes: {:?}", key_bytes);
 
-        // TODO(perf): do not double lookup when changing the value later (borrow needs to be split for preload_nodes though)
-        let mut cache_leaf_entry = self.cache_leaf_modified.entry_ref(&key_bytes[..]);
-
-        if let hash_map::EntryRef::Occupied(entry) = &mut cache_leaf_entry {
-            if matches!(entry.get(), InsertOrRemove::Insert(_)) {
-                entry.insert(InsertOrRemove::Insert(value));
-                return Ok(());
-            }
-        }
-
         if let Some(value_db) = db.get(&TrieKey::new(
             &self.identifier,
             TrieKeyType::Flat,
@@ -1622,5 +1612,46 @@ mod staged_hash_cache_tests {
             "retained frontier should stay small for a single recently touched branch, got {} nodes",
             tree.nodes.len()
         );
+    }
+
+    #[test]
+    fn duplicate_staged_insert_invalidates_cached_root() {
+        let identifier = vec![];
+        let key = BitVec::from_vec(vec![0b1000_0000]);
+        let value_one = Felt::from_hex("0x11").unwrap();
+        let value_two = Felt::from_hex("0x22").unwrap();
+
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        bonsai_storage
+            .insert(&identifier, &key, &value_one)
+            .unwrap();
+        let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+
+        bonsai_storage
+            .insert(&identifier, &key, &value_two)
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+        let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+        let mut comparison_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut comparison_ids = BasicIdBuilder::new();
+        comparison_storage
+            .insert(&identifier, &key, &value_two)
+            .unwrap();
+        comparison_storage.commit(comparison_ids.new_id()).unwrap();
+        let expected_root = comparison_storage.root_hash(&identifier).unwrap();
+
+        assert_ne!(staged_root, expected_root);
+        assert_eq!(committed_root, expected_root);
     }
 }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -952,14 +952,21 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
         let key_bytes = bitslice_to_bytes(key);
         log::trace!("key_bytes: {:?}", key_bytes);
+        let has_staged_override = match self.cache_leaf_modified.get(&key_bytes) {
+            Some(InsertOrRemove::Insert(staged_value)) if *staged_value == value => return Ok(()),
+            Some(_) => true,
+            None => false,
+        };
 
-        if let Some(value_db) = db.get(&TrieKey::new(
-            &self.identifier,
-            TrieKeyType::Flat,
-            &key_bytes,
-        ))? {
-            if value == Felt::decode(&mut value_db.as_slice()).unwrap() {
-                return Ok(());
+        if !has_staged_override {
+            if let Some(value_db) = db.get(&TrieKey::new(
+                &self.identifier,
+                TrieKeyType::Flat,
+                &key_bytes,
+            ))? {
+                if value == Felt::decode(&mut value_db.as_slice()).unwrap() {
+                    return Ok(());
+                }
             }
         }
 
@@ -1653,5 +1660,39 @@ mod staged_hash_cache_tests {
 
         assert_ne!(staged_root, expected_root);
         assert_eq!(committed_root, expected_root);
+    }
+
+    #[test]
+    fn restoring_committed_value_overrides_staged_mutation() {
+        let identifier = vec![];
+        let key = BitVec::from_vec(vec![0b1000_0000]);
+        let committed_value = Felt::from_hex("0x11").unwrap();
+        let transient_value = Felt::from_hex("0x22").unwrap();
+
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        bonsai_storage
+            .insert(&identifier, &key, &committed_value)
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+        let original_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+        bonsai_storage
+            .insert(&identifier, &key, &transient_value)
+            .unwrap();
+        bonsai_storage
+            .insert(&identifier, &key, &committed_value)
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        assert_eq!(
+            bonsai_storage.root_hash(&identifier).unwrap(),
+            original_root
+        );
     }
 }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -411,7 +411,8 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     #[allow(clippy::type_complexity)]
     pub(crate) fn get_updates<DB: BonsaiDatabase>(
         &mut self,
-    ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>>
+    {
         let dirty_before_commit = self.dirty;
         let mut updates = HashMap::new();
         for node_key in mem::take(&mut self.death_row) {
@@ -549,7 +550,8 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                     self.perf_stats.db_node_loads,
                     self.perf_stats.in_memory_node_hits,
                 );
-                self.staged_hashes.store(StagedHashComputation { root_hash, hashes });
+                self.staged_hashes
+                    .store(StagedHashComputation { root_hash, hashes });
                 Ok(root_hash)
             }
             Some(RootHandle::Empty) => Ok(Felt::ZERO),
@@ -682,9 +684,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         path: Path,
         hashes: &mut impl Iterator<Item = Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
-        match self.nodes.get(node_id).cloned().ok_or(BonsaiStorageError::Trie(
-            "Couldn't fetch node in the temporary storage".to_string(),
-        ))? {
+        match self
+            .nodes
+            .get(node_id)
+            .cloned()
+            .ok_or(BonsaiStorageError::Trie(
+                "Couldn't fetch node in the temporary storage".to_string(),
+            ))? {
             Node::Binary(binary) => {
                 let left_path = path.new_with_direction(Direction::Left);
                 let left_hash = match binary.left {

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -208,13 +208,11 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
             .trees
             .par_iter_mut()
             .map(|(_, tree)| tree.get_updates::<DB>())
-            .collect_vec_list()
-            .into_iter()
-            .flatten();
+            .collect::<Vec<_>>();
 
         let mut batch = self.db.create_batch();
         for changes in db_changes {
-            for (key, value) in changes? {
+            for (key, value) in changes?.into_iter() {
                 match value {
                     InsertOrRemove::Insert(value) => {
                         self.db.insert(&key, &value, Some(&mut batch))?;


### PR DESCRIPTION
## Summary
- reuse `root_hash_staged()` work during commit instead of hashing the same modified subtree twice
- make trie commit non-destructive so touched nodes stay resident as a hot frontier after commit
- add debug logs and tests around staged root reuse, repeated incremental commits, and clean no-op commits

## Testing
- cargo test staged --manifest-path /Users/heemankverma/Work/Karnot/bonsai-trie/Cargo.toml
- cargo test --manifest-path /Users/heemankverma/Work/Karnot/bonsai-trie/Cargo.toml