### PR TITLE
perf: insert owned trie keys

### DIFF
--- a/src/bonsai_database.rs
+++ b/src/bonsai_database.rs
@@ -67,6 +67,25 @@ pub trait BonsaiDatabase: core::fmt::Debug {
         batch: Option<&mut Self::Batch>,
     ) -> Result<Option<ByteVec>, Self::DatabaseError>;
 
+    /// Insert a key-value pair into a batch without returning or tracking the old value.
+    fn insert_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        value: &[u8],
+        batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        self.insert(key, value, Some(batch)).map(|_| ())
+    }
+
+    /// Remove a key-value pair from a batch without returning or tracking the old value.
+    fn remove_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        self.remove(key, Some(batch)).map(|_| ())
+    }
+
     /// Remove all keys that start with the given prefix
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError>;
 

--- a/src/databases/hashmap_db.rs
+++ b/src/databases/hashmap_db.rs
@@ -100,6 +100,17 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
         Ok(db.insert(key.as_slice().into(), value.into()))
     }
 
+    fn insert_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        value: &[u8],
+        _batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        let db = self.get_map_mut(key);
+        db.insert(key.as_slice().into(), value.into());
+        Ok(())
+    }
+
     fn remove(
         &mut self,
         key: &DatabaseKey,
@@ -107,6 +118,16 @@ impl<ID: Id> BonsaiDatabase for HashMapDb<ID> {
     ) -> Result<Option<ByteVec>, Self::DatabaseError> {
         let db = self.get_map_mut(key);
         Ok(db.remove(key.as_slice()))
+    }
+
+    fn remove_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        _batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        let db = self.get_map_mut(key);
+        db.remove(key.as_slice());
+        Ok(())
     }
 
     fn contains(&self, key: &DatabaseKey) -> Result<bool, Self::DatabaseError> {

--- a/src/databases/rocks_db.rs
+++ b/src/databases/rocks_db.rs
@@ -212,6 +212,18 @@ where
         Ok(old_value.map(Into::into))
     }
 
+    fn insert_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        value: &[u8],
+        batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        trace!("Inserting untracked into RocksDB: {:?} {:?}", key, value);
+        let handle_cf = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
+        batch.put_cf(&handle_cf, key.as_slice(), value);
+        Ok(())
+    }
+
     fn get(&self, key: &DatabaseKey) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", key);
         let handle = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
@@ -266,6 +278,17 @@ where
             self.db.delete_cf(&handle, key.as_slice())?;
         }
         Ok(old_value.map(Into::into))
+    }
+
+    fn remove_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        trace!("Removing untracked from RocksDB: {:?}", key);
+        let handle = self.db.cf_handle(key.get_cf()).expect(CF_ERROR);
+        batch.delete_cf(&handle, key.as_slice());
+        Ok(())
     }
 
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError> {
@@ -356,6 +379,18 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
         Ok(old_value.map(Into::into))
     }
 
+    fn insert_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        value: &[u8],
+        batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        trace!("Inserting untracked into RocksDB: {:?} {:?}", key, value);
+        let handle_cf = self.column_families.get(key.get_cf()).expect(CF_ERROR);
+        batch.put_cf(handle_cf, key.as_slice(), value);
+        Ok(())
+    }
+
     fn get(&self, key: &DatabaseKey) -> Result<Option<ByteVec>, Self::DatabaseError> {
         trace!("Getting from RocksDB: {:?}", key);
         let handle = self.column_families.get(key.get_cf()).expect(CF_ERROR);
@@ -415,6 +450,17 @@ impl<'db> BonsaiDatabase for RocksDBTransaction<'db> {
             self.txn.delete_cf(handle, key.as_slice())?;
         }
         Ok(old_value.map(Into::into))
+    }
+
+    fn remove_untracked(
+        &mut self,
+        key: &DatabaseKey,
+        batch: &mut Self::Batch,
+    ) -> Result<(), Self::DatabaseError> {
+        trace!("Removing untracked from RocksDB: {:?}", key);
+        let handle = self.column_families.get(key.get_cf()).expect(CF_ERROR);
+        batch.delete_cf(handle, key.as_slice());
+        Ok(())
     }
 
     fn remove_by_prefix(&mut self, prefix: &DatabaseKey) -> Result<(), Self::DatabaseError> {

--- a/src/key_value_db.rs
+++ b/src/key_value_db.rs
@@ -196,6 +196,16 @@ where
         Ok(())
     }
 
+    pub(crate) fn insert_untracked(
+        &mut self,
+        key: &TrieKey,
+        value: &[u8],
+        batch: &mut DB::Batch,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        trace!("Inserting untracked into KeyValueDB: {:?} {:?}", key, value);
+        Ok(self.db.insert_untracked(&key.into(), value, batch)?)
+    }
+
     pub(crate) fn remove(
         &mut self,
         key: &TrieKey,
@@ -211,6 +221,15 @@ where
             },
         );
         Ok(())
+    }
+
+    pub(crate) fn remove_untracked(
+        &mut self,
+        key: &TrieKey,
+        batch: &mut DB::Batch,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        trace!("Removing untracked from KeyValueDB: {:?}", key);
+        Ok(self.db.remove_untracked(&key.into(), batch)?)
     }
 
     pub(crate) fn write_batch(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,43 @@ pub type ByteVec = smallvec::SmallVec<[u8; 32]>;
 pub type BitVec = bitvec::vec::BitVec<u8, bitvec::order::Msb0>;
 pub type BitSlice = bitvec::slice::BitSlice<u8, bitvec::order::Msb0>;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BulkInsertStats {
+    pub input_entries: u64,
+    pub prepared_entries: u64,
+    pub duplicate_entries: u64,
+    pub db_node_loads: u64,
+    pub in_memory_node_hits: u64,
+    pub loaded_handles: u64,
+    pub updated_binary_nodes: u64,
+    pub updated_edge_nodes: u64,
+    pub split_edge_nodes: u64,
+    pub built_binary_nodes: u64,
+    pub built_edge_nodes: u64,
+    pub leaf_updates: u64,
+    pub max_range_entries: u64,
+    pub max_build_depth: u64,
+}
+
+impl BulkInsertStats {
+    pub fn merge(&mut self, other: Self) {
+        self.input_entries += other.input_entries;
+        self.prepared_entries += other.prepared_entries;
+        self.duplicate_entries += other.duplicate_entries;
+        self.db_node_loads += other.db_node_loads;
+        self.in_memory_node_hits += other.in_memory_node_hits;
+        self.loaded_handles += other.loaded_handles;
+        self.updated_binary_nodes += other.updated_binary_nodes;
+        self.updated_edge_nodes += other.updated_edge_nodes;
+        self.split_edge_nodes += other.split_edge_nodes;
+        self.built_binary_nodes += other.built_binary_nodes;
+        self.built_edge_nodes += other.built_edge_nodes;
+        self.leaf_updates += other.leaf_updates;
+        self.max_range_entries = self.max_range_entries.max(other.max_range_entries);
+        self.max_build_depth = self.max_build_depth.max(other.max_build_depth);
+    }
+}
+
 mod changes;
 mod key_value_db;
 mod trie;
@@ -313,6 +350,18 @@ where
         self.tries
             .set_many_owned_assume_changed(identifier, entries)?;
         Ok(())
+    }
+
+    pub fn insert_many_owned_assume_changed_with_stats<I>(
+        &mut self,
+        identifier: &[u8],
+        entries: I,
+    ) -> Result<BulkInsertStats, BonsaiStorageError<DB::DatabaseError>>
+    where
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        self.tries
+            .set_many_owned_assume_changed_with_stats(identifier, entries)
     }
 
     /// Remove a key/value in the trie

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,27 +315,6 @@ where
         Ok(())
     }
 
-    /// Insert multiple groups of key/value pairs into independent tries when
-    /// the caller already knows every entry is a real state change.
-    ///
-    /// Each identifier is updated with the same semantics as
-    /// [`Self::insert_many_owned_assume_changed`]. With the `std` feature,
-    /// independent tries can be mutated in parallel.
-    pub fn insert_many_by_identifier_owned_assume_changed<I, E>(
-        &mut self,
-        updates: I,
-    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
-    where
-        DB: Sync,
-        ChangeID: Sync,
-        I: IntoIterator<Item = (ByteVec, E)>,
-        E: IntoIterator<Item = (BitVec, Felt)>,
-    {
-        self.tries
-            .set_many_by_identifier_owned_assume_changed(updates)?;
-        Ok(())
-    }
-
     /// Remove a key/value in the trie
     /// If the value doesn't exist it will do nothing
     pub fn remove(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,25 @@ where
         Ok(())
     }
 
+    /// Insert multiple key/value pairs into the same trie when the caller
+    /// already knows every entry is a real state change.
+    ///
+    /// This skips the committed flat-value lookup used by [`Self::insert`] to
+    /// detect no-op writes. It is intended for state-diff application paths,
+    /// not for arbitrary user writes.
+    pub fn insert_many_owned_assume_changed<I>(
+        &mut self,
+        identifier: &[u8],
+        entries: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        self.tries
+            .set_many_owned_assume_changed(identifier, entries)?;
+        Ok(())
+    }
+
     /// Remove a key/value in the trie
     /// If the value doesn't exist it will do nothing
     pub fn remove(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,24 @@ where
         Ok(())
     }
 
+    /// Insert multiple key/value pairs into the same trie using owned bit-vector
+    /// keys.
+    ///
+    /// This preserves the same semantics as repeated [`Self::insert_owned`]
+    /// calls while letting callers group updates by identifier and avoid
+    /// repeatedly resolving the same inner trie.
+    pub fn insert_many_owned<I>(
+        &mut self,
+        identifier: &[u8],
+        entries: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        self.tries.set_many_owned(identifier, entries)?;
+        Ok(())
+    }
+
     /// Remove a key/value in the trie
     /// If the value doesn't exist it will do nothing
     pub fn remove(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,8 @@ pub struct BulkInsertStats {
     pub input_entries: u64,
     pub prepared_entries: u64,
     pub duplicate_entries: u64,
+    pub retained_nodes_before: u64,
+    pub retained_nodes_after: u64,
     pub db_node_loads: u64,
     pub in_memory_node_hits: u64,
     pub loaded_handles: u64,
@@ -138,6 +140,8 @@ impl BulkInsertStats {
         self.input_entries += other.input_entries;
         self.prepared_entries += other.prepared_entries;
         self.duplicate_entries += other.duplicate_entries;
+        self.retained_nodes_before += other.retained_nodes_before;
+        self.retained_nodes_after += other.retained_nodes_after;
         self.db_node_loads += other.db_node_loads;
         self.in_memory_node_hits += other.in_memory_node_hits;
         self.loaded_handles += other.loaded_handles;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,27 @@ where
         Ok(())
     }
 
+    /// Insert multiple groups of key/value pairs into independent tries when
+    /// the caller already knows every entry is a real state change.
+    ///
+    /// Each identifier is updated with the same semantics as
+    /// [`Self::insert_many_owned_assume_changed`]. With the `std` feature,
+    /// independent tries can be mutated in parallel.
+    pub fn insert_many_by_identifier_owned_assume_changed<I, E>(
+        &mut self,
+        updates: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        DB: Sync,
+        ChangeID: Sync,
+        I: IntoIterator<Item = (ByteVec, E)>,
+        E: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        self.tries
+            .set_many_by_identifier_owned_assume_changed(updates)?;
+        Ok(())
+    }
+
     /// Remove a key/value in the trie
     /// If the value doesn't exist it will do nothing
     pub fn remove(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,20 @@ where
         Ok(())
     }
 
+    /// Insert a new key/value using an owned bit-vector key.
+    ///
+    /// This preserves the existing trie traversal semantics while avoiding the
+    /// extra bit-vector allocation otherwise needed to encode the flat key.
+    pub fn insert_owned(
+        &mut self,
+        identifier: &[u8],
+        key: BitVec,
+        value: &Felt,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        self.tries.set_owned(identifier, key, *value)?;
+        Ok(())
+    }
+
     /// Remove a key/value in the trie
     /// If the value doesn't exist it will do nothing
     pub fn remove(

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -340,6 +340,57 @@ fn insert_many_owned_matches_repeated_insert_for_starknet_keys() {
 }
 
 #[test]
+fn insert_many_owned_assume_changed_matches_repeated_insert_for_starknet_keys() {
+    let identifier = vec![44];
+    let tempdir1 = tempfile::tempdir().unwrap();
+    let db1 = create_rocks_db(tempdir1.path()).unwrap();
+    let mut repeated_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db1, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let tempdir2 = tempfile::tempdir().unwrap();
+    let db2 = create_rocks_db(tempdir2.path()).unwrap();
+    let mut unchecked_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db2, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let updates = [
+        ("0x123456789abcdef0123456789abcdef", "0x2"),
+        ("0x100000000000000000000000000000000000000", "0x3"),
+        ("0x200000000000000000000000000000000000000", "0x4"),
+    ];
+
+    let mut unchecked_updates = Vec::new();
+    for (key, value) in updates {
+        let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
+        let value = Felt::from_hex(value).unwrap();
+        repeated_storage.insert(&identifier, &key, &value).unwrap();
+        unchecked_updates.push((key, value));
+    }
+    unchecked_storage
+        .insert_many_owned_assume_changed(&identifier, unchecked_updates)
+        .unwrap();
+
+    assert_eq!(
+        repeated_storage.root_hash_staged(&identifier).unwrap(),
+        unchecked_storage.root_hash_staged(&identifier).unwrap()
+    );
+
+    let id = BasicIdBuilder::new().new_id();
+    repeated_storage.commit(id).unwrap();
+    unchecked_storage.commit(id).unwrap();
+
+    assert_eq!(
+        repeated_storage.root_hash(&identifier).unwrap(),
+        unchecked_storage.root_hash(&identifier).unwrap()
+    );
+}
+
+#[test]
 fn root_hash_similar_hashmap_db() {
     let identifier = vec![];
     let root_hash_1 = {

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -2,7 +2,7 @@
 use crate::{
     databases::{create_rocks_db, HashMapDb, RocksDB, RocksDBConfig},
     id::{BasicId, BasicIdBuilder},
-    BitVec, BonsaiStorage, BonsaiStorageConfig, Change,
+    BitVec, BonsaiStorage, BonsaiStorageConfig, ByteVec, Change,
 };
 use bitvec::view::BitView;
 use starknet_types_core::{felt::Felt, hash::Pedersen};
@@ -388,6 +388,76 @@ fn insert_many_owned_assume_changed_matches_repeated_insert_for_starknet_keys() 
         repeated_storage.root_hash(&identifier).unwrap(),
         unchecked_storage.root_hash(&identifier).unwrap()
     );
+}
+
+#[test]
+fn insert_many_by_identifier_owned_assume_changed_matches_repeated_insert() {
+    let tempdir1 = tempfile::tempdir().unwrap();
+    let db1 = create_rocks_db(tempdir1.path()).unwrap();
+    let mut repeated_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db1, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let tempdir2 = tempfile::tempdir().unwrap();
+    let db2 = create_rocks_db(tempdir2.path()).unwrap();
+    let mut bulk_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db2, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let updates = [
+        (
+            ByteVec::from_slice(&[1]),
+            vec![
+                ("0x123456789abcdef0123456789abcdef", "0x2"),
+                ("0x100000000000000000000000000000000000000", "0x3"),
+            ],
+        ),
+        (
+            ByteVec::from_slice(&[2]),
+            vec![
+                ("0x200000000000000000000000000000000000000", "0x4"),
+                ("0x300000000000000000000000000000000000000", "0x5"),
+            ],
+        ),
+    ];
+
+    let mut bulk_updates = Vec::new();
+    for (identifier, entries) in updates {
+        let mut bulk_entries = Vec::new();
+        for (key, value) in entries {
+            let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
+            let value = Felt::from_hex(value).unwrap();
+            repeated_storage.insert(&identifier, &key, &value).unwrap();
+            bulk_entries.push((key, value));
+        }
+        bulk_updates.push((identifier, bulk_entries));
+    }
+
+    bulk_storage
+        .insert_many_by_identifier_owned_assume_changed(bulk_updates)
+        .unwrap();
+
+    for identifier in [ByteVec::from_slice(&[1]), ByteVec::from_slice(&[2])] {
+        assert_eq!(
+            repeated_storage.root_hash_staged(&identifier).unwrap(),
+            bulk_storage.root_hash_staged(&identifier).unwrap()
+        );
+    }
+
+    let id = BasicIdBuilder::new().new_id();
+    repeated_storage.commit(id).unwrap();
+    bulk_storage.commit(id).unwrap();
+
+    for identifier in [ByteVec::from_slice(&[1]), ByteVec::from_slice(&[2])] {
+        assert_eq!(
+            repeated_storage.root_hash(&identifier).unwrap(),
+            bulk_storage.root_hash(&identifier).unwrap()
+        );
+    }
 }
 
 #[test]

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -2,7 +2,7 @@
 use crate::{
     databases::{create_rocks_db, HashMapDb, RocksDB, RocksDBConfig},
     id::{BasicId, BasicIdBuilder},
-    BitVec, BonsaiStorage, BonsaiStorageConfig, ByteVec, Change,
+    BitVec, BonsaiStorage, BonsaiStorageConfig, Change,
 };
 use bitvec::view::BitView;
 use starknet_types_core::{felt::Felt, hash::Pedersen};
@@ -388,76 +388,6 @@ fn insert_many_owned_assume_changed_matches_repeated_insert_for_starknet_keys() 
         repeated_storage.root_hash(&identifier).unwrap(),
         unchecked_storage.root_hash(&identifier).unwrap()
     );
-}
-
-#[test]
-fn insert_many_by_identifier_owned_assume_changed_matches_repeated_insert() {
-    let tempdir1 = tempfile::tempdir().unwrap();
-    let db1 = create_rocks_db(tempdir1.path()).unwrap();
-    let mut repeated_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
-        RocksDB::new(&db1, RocksDBConfig::default()),
-        BonsaiStorageConfig::default(),
-        251,
-    );
-
-    let tempdir2 = tempfile::tempdir().unwrap();
-    let db2 = create_rocks_db(tempdir2.path()).unwrap();
-    let mut bulk_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
-        RocksDB::new(&db2, RocksDBConfig::default()),
-        BonsaiStorageConfig::default(),
-        251,
-    );
-
-    let updates = [
-        (
-            ByteVec::from_slice(&[1]),
-            vec![
-                ("0x123456789abcdef0123456789abcdef", "0x2"),
-                ("0x100000000000000000000000000000000000000", "0x3"),
-            ],
-        ),
-        (
-            ByteVec::from_slice(&[2]),
-            vec![
-                ("0x200000000000000000000000000000000000000", "0x4"),
-                ("0x300000000000000000000000000000000000000", "0x5"),
-            ],
-        ),
-    ];
-
-    let mut bulk_updates = Vec::new();
-    for (identifier, entries) in updates {
-        let mut bulk_entries = Vec::new();
-        for (key, value) in entries {
-            let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
-            let value = Felt::from_hex(value).unwrap();
-            repeated_storage.insert(&identifier, &key, &value).unwrap();
-            bulk_entries.push((key, value));
-        }
-        bulk_updates.push((identifier, bulk_entries));
-    }
-
-    bulk_storage
-        .insert_many_by_identifier_owned_assume_changed(bulk_updates)
-        .unwrap();
-
-    for identifier in [ByteVec::from_slice(&[1]), ByteVec::from_slice(&[2])] {
-        assert_eq!(
-            repeated_storage.root_hash_staged(&identifier).unwrap(),
-            bulk_storage.root_hash_staged(&identifier).unwrap()
-        );
-    }
-
-    let id = BasicIdBuilder::new().new_id();
-    repeated_storage.commit(id).unwrap();
-    bulk_storage.commit(id).unwrap();
-
-    for identifier in [ByteVec::from_slice(&[1]), ByteVec::from_slice(&[2])] {
-        assert_eq!(
-            repeated_storage.root_hash(&identifier).unwrap(),
-            bulk_storage.root_hash(&identifier).unwrap()
-        );
-    }
 }
 
 #[test]

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -311,6 +311,7 @@ fn insert_many_owned_matches_repeated_insert_for_starknet_keys() {
         ("0x123456789abcdef0123456789abcdef", "0x5"),
         ("0x100000000000000000000000000000000000000", "0x3"),
         ("0x200000000000000000000000000000000000000", "0x4"),
+        ("0x100000000000000000000000000000000000000", "0x6"),
     ];
 
     let mut batched_updates = Vec::new();
@@ -362,6 +363,7 @@ fn insert_many_owned_assume_changed_matches_repeated_insert_for_starknet_keys() 
         ("0x123456789abcdef0123456789abcdef", "0x2"),
         ("0x100000000000000000000000000000000000000", "0x3"),
         ("0x200000000000000000000000000000000000000", "0x4"),
+        ("0x100000000000000000000000000000000000000", "0x6"),
     ];
 
     let mut unchecked_updates = Vec::new();

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -393,6 +393,98 @@ fn insert_many_owned_assume_changed_matches_repeated_insert_for_starknet_keys() 
 }
 
 #[test]
+fn insert_many_owned_assume_changed_updates_committed_trie_like_repeated_insert() {
+    let identifier = vec![45];
+    let tempdir1 = tempfile::tempdir().unwrap();
+    let db1 = create_rocks_db(tempdir1.path()).unwrap();
+    let mut repeated_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db1, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let tempdir2 = tempfile::tempdir().unwrap();
+    let db2 = create_rocks_db(tempdir2.path()).unwrap();
+    let mut bulk_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db2, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let initial = [
+        (
+            "0x0100000000000000000000000000000000000000000000000000000000000001",
+            "0x11",
+        ),
+        (
+            "0x0100000000000000000000000000000000000000000000000000000000000100",
+            "0x12",
+        ),
+        (
+            "0x0300000000000000000000000000000000000000000000000000000000000000",
+            "0x13",
+        ),
+    ];
+
+    for (key, value) in initial {
+        let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
+        let value = Felt::from_hex(value).unwrap();
+        repeated_storage.insert(&identifier, &key, &value).unwrap();
+        bulk_storage.insert(&identifier, &key, &value).unwrap();
+    }
+
+    let mut id_builder = BasicIdBuilder::new();
+    let initial_id = id_builder.new_id();
+    repeated_storage.commit(initial_id).unwrap();
+    bulk_storage.commit(initial_id).unwrap();
+
+    let updates = [
+        (
+            "0x0100000000000000000000000000000000000000000000000000000000000001",
+            "0x21",
+        ),
+        (
+            "0x0100000000000000000000000000000000000000000000000000000000000002",
+            "0x22",
+        ),
+        (
+            "0x0180000000000000000000000000000000000000000000000000000000000000",
+            "0x23",
+        ),
+        (
+            "0x0380000000000000000000000000000000000000000000000000000000000000",
+            "0x24",
+        ),
+    ];
+
+    let mut bulk_updates = Vec::new();
+    for (key, value) in updates {
+        let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
+        let value = Felt::from_hex(value).unwrap();
+        repeated_storage.insert(&identifier, &key, &value).unwrap();
+        bulk_updates.push((key, value));
+    }
+
+    bulk_storage
+        .insert_many_owned_assume_changed(&identifier, bulk_updates)
+        .unwrap();
+
+    assert_eq!(
+        repeated_storage.root_hash_staged(&identifier).unwrap(),
+        bulk_storage.root_hash_staged(&identifier).unwrap()
+    );
+
+    let update_id = id_builder.new_id();
+    repeated_storage.commit(update_id).unwrap();
+    bulk_storage.commit(update_id).unwrap();
+
+    assert_eq!(
+        repeated_storage.root_hash(&identifier).unwrap(),
+        bulk_storage.root_hash(&identifier).unwrap()
+    );
+}
+
+#[test]
 fn root_hash_similar_hashmap_db() {
     let identifier = vec![];
     let root_hash_1 = {

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -284,6 +284,62 @@ fn insert_owned_matches_regular_insert_for_starknet_keys() {
 }
 
 #[test]
+fn insert_many_owned_matches_repeated_insert_for_starknet_keys() {
+    let identifier = vec![43];
+    let tempdir1 = tempfile::tempdir().unwrap();
+    let db1 = create_rocks_db(tempdir1.path()).unwrap();
+    let mut repeated_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db1, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let tempdir2 = tempfile::tempdir().unwrap();
+    let db2 = create_rocks_db(tempdir2.path()).unwrap();
+    let mut batched_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db2, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let updates = [
+        (
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "0x1",
+        ),
+        ("0x123456789abcdef0123456789abcdef", "0x2"),
+        ("0x123456789abcdef0123456789abcdef", "0x5"),
+        ("0x100000000000000000000000000000000000000", "0x3"),
+        ("0x200000000000000000000000000000000000000", "0x4"),
+    ];
+
+    let mut batched_updates = Vec::new();
+    for (key, value) in updates {
+        let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
+        let value = Felt::from_hex(value).unwrap();
+        repeated_storage.insert(&identifier, &key, &value).unwrap();
+        batched_updates.push((key, value));
+    }
+    batched_storage
+        .insert_many_owned(&identifier, batched_updates)
+        .unwrap();
+
+    assert_eq!(
+        repeated_storage.root_hash_staged(&identifier).unwrap(),
+        batched_storage.root_hash_staged(&identifier).unwrap()
+    );
+
+    let id = BasicIdBuilder::new().new_id();
+    repeated_storage.commit(id).unwrap();
+    batched_storage.commit(id).unwrap();
+
+    assert_eq!(
+        repeated_storage.root_hash(&identifier).unwrap(),
+        batched_storage.root_hash(&identifier).unwrap()
+    );
+}
+
+#[test]
 fn root_hash_similar_hashmap_db() {
     let identifier = vec![];
     let root_hash_1 = {

--- a/src/tests/simple.rs
+++ b/src/tests/simple.rs
@@ -231,6 +231,59 @@ fn starknet_specific() {
 }
 
 #[test]
+fn insert_owned_matches_regular_insert_for_starknet_keys() {
+    let identifier = vec![42];
+    let tempdir1 = tempfile::tempdir().unwrap();
+    let db1 = create_rocks_db(tempdir1.path()).unwrap();
+    let mut regular_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db1, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let tempdir2 = tempfile::tempdir().unwrap();
+    let db2 = create_rocks_db(tempdir2.path()).unwrap();
+    let mut owned_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db2, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        251,
+    );
+
+    let updates = [
+        (
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "0x1",
+        ),
+        ("0x123456789abcdef0123456789abcdef", "0x2"),
+        ("0x100000000000000000000000000000000000000", "0x3"),
+        ("0x200000000000000000000000000000000000000", "0x4"),
+    ];
+
+    for (key, value) in updates {
+        let key = Felt::from_hex(key).unwrap().to_bytes_be().view_bits()[5..].to_bitvec();
+        let value = Felt::from_hex(value).unwrap();
+        regular_storage.insert(&identifier, &key, &value).unwrap();
+        owned_storage
+            .insert_owned(&identifier, key, &value)
+            .unwrap();
+    }
+
+    assert_eq!(
+        regular_storage.root_hash_staged(&identifier).unwrap(),
+        owned_storage.root_hash_staged(&identifier).unwrap()
+    );
+
+    let id = BasicIdBuilder::new().new_id();
+    regular_storage.commit(id).unwrap();
+    owned_storage.commit(id).unwrap();
+
+    assert_eq!(
+        regular_storage.root_hash(&identifier).unwrap(),
+        owned_storage.root_hash(&identifier).unwrap()
+    );
+}
+
+#[test]
 fn root_hash_similar_hashmap_db() {
     let identifier = vec![];
     let root_hash_1 = {

--- a/src/tests/staged.rs
+++ b/src/tests/staged.rs
@@ -11,9 +11,8 @@ fn staged_root_matches_committed_root() {
     let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
-    let config = BonsaiStorageConfig::default();
     let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
     let mut id_builder = BasicIdBuilder::new();
 
     let pair1 = (
@@ -224,4 +223,95 @@ fn staged_root_with_multiple_identifiers() {
 
     assert_eq!(staged_a, committed_a);
     assert_eq!(staged_b, committed_b);
+}
+
+#[test]
+fn staged_root_after_multiple_incremental_commits() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let config = BonsaiStorageConfig::default();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), config, 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pairs = vec![
+        (
+            vec![1, 2, 1],
+            Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+        ),
+        (
+            vec![1, 2, 2],
+            Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052e").unwrap(),
+        ),
+        (
+            vec![1, 2, 3],
+            Felt::from_hex("0x66342762FD54D033c195fec3ce2568b62052f").unwrap(),
+        ),
+    ];
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pairs[0].0.clone()), &pairs[0].1)
+        .unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pairs[1].0.clone()), &pairs[1].1)
+        .unwrap();
+    let staged_round_two = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    assert_eq!(staged_round_two, bonsai_storage.root_hash(&identifier).unwrap());
+
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pairs[2].0.clone()), &pairs[2].1)
+        .unwrap();
+    let staged_round_three = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    let final_root = bonsai_storage.root_hash(&identifier).unwrap();
+    assert_eq!(staged_round_three, final_root);
+
+    let comparison_tempdir = tempfile::tempdir().unwrap();
+    let comparison_db = create_rocks_db(comparison_tempdir.path()).unwrap();
+    let mut comparison_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(
+            RocksDB::new(&comparison_db, RocksDBConfig::default()),
+            BonsaiStorageConfig::default(),
+            24,
+        );
+    let mut comparison_ids = BasicIdBuilder::new();
+    for (key, value) in pairs {
+        comparison_storage
+            .insert(&identifier, &BitVec::from_vec(key), &value)
+            .unwrap();
+    }
+    comparison_storage.commit(comparison_ids.new_id()).unwrap();
+
+    assert_eq!(final_root, comparison_storage.root_hash(&identifier).unwrap());
+}
+
+#[test]
+fn clean_commit_with_retained_frontier_is_noop() {
+    let identifier = vec![];
+    let tempdir = tempfile::tempdir().unwrap();
+    let db = create_rocks_db(tempdir.path()).unwrap();
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
+        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
+    let mut id_builder = BasicIdBuilder::new();
+
+    let pair = (
+        vec![1, 2, 1],
+        Felt::from_hex("0x66342762FDD54D033c195fec3ce2568b62052e").unwrap(),
+    );
+    bonsai_storage
+        .insert(&identifier, &BitVec::from_vec(pair.0.clone()), &pair.1)
+        .unwrap();
+
+    let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    assert_eq!(staged_root, bonsai_storage.root_hash(&identifier).unwrap());
+
+    // Second commit has no new mutations and should keep the already-loaded frontier stable.
+    bonsai_storage.commit(id_builder.new_id()).unwrap();
+    assert_eq!(staged_root, bonsai_storage.root_hash(&identifier).unwrap());
+    assert_eq!(staged_root, bonsai_storage.root_hash_staged(&identifier).unwrap());
 }

--- a/src/tests/staged.rs
+++ b/src/tests/staged.rs
@@ -11,8 +11,11 @@ fn staged_root_matches_committed_root() {
     let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
-    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        24,
+    );
     let mut id_builder = BasicIdBuilder::new();
 
     let pair1 = (
@@ -251,19 +254,34 @@ fn staged_root_after_multiple_incremental_commits() {
     ];
 
     bonsai_storage
-        .insert(&identifier, &BitVec::from_vec(pairs[0].0.clone()), &pairs[0].1)
+        .insert(
+            &identifier,
+            &BitVec::from_vec(pairs[0].0.clone()),
+            &pairs[0].1,
+        )
         .unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
 
     bonsai_storage
-        .insert(&identifier, &BitVec::from_vec(pairs[1].0.clone()), &pairs[1].1)
+        .insert(
+            &identifier,
+            &BitVec::from_vec(pairs[1].0.clone()),
+            &pairs[1].1,
+        )
         .unwrap();
     let staged_round_two = bonsai_storage.root_hash_staged(&identifier).unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
-    assert_eq!(staged_round_two, bonsai_storage.root_hash(&identifier).unwrap());
+    assert_eq!(
+        staged_round_two,
+        bonsai_storage.root_hash(&identifier).unwrap()
+    );
 
     bonsai_storage
-        .insert(&identifier, &BitVec::from_vec(pairs[2].0.clone()), &pairs[2].1)
+        .insert(
+            &identifier,
+            &BitVec::from_vec(pairs[2].0.clone()),
+            &pairs[2].1,
+        )
         .unwrap();
     let staged_round_three = bonsai_storage.root_hash_staged(&identifier).unwrap();
     bonsai_storage.commit(id_builder.new_id()).unwrap();
@@ -272,12 +290,11 @@ fn staged_root_after_multiple_incremental_commits() {
 
     let comparison_tempdir = tempfile::tempdir().unwrap();
     let comparison_db = create_rocks_db(comparison_tempdir.path()).unwrap();
-    let mut comparison_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(
-            RocksDB::new(&comparison_db, RocksDBConfig::default()),
-            BonsaiStorageConfig::default(),
-            24,
-        );
+    let mut comparison_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&comparison_db, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        24,
+    );
     let mut comparison_ids = BasicIdBuilder::new();
     for (key, value) in pairs {
         comparison_storage
@@ -286,7 +303,10 @@ fn staged_root_after_multiple_incremental_commits() {
     }
     comparison_storage.commit(comparison_ids.new_id()).unwrap();
 
-    assert_eq!(final_root, comparison_storage.root_hash(&identifier).unwrap());
+    assert_eq!(
+        final_root,
+        comparison_storage.root_hash(&identifier).unwrap()
+    );
 }
 
 #[test]
@@ -294,8 +314,11 @@ fn clean_commit_with_retained_frontier_is_noop() {
     let identifier = vec![];
     let tempdir = tempfile::tempdir().unwrap();
     let db = create_rocks_db(tempdir.path()).unwrap();
-    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> =
-        BonsaiStorage::new(RocksDB::new(&db, RocksDBConfig::default()), BonsaiStorageConfig::default(), 24);
+    let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+        RocksDB::new(&db, RocksDBConfig::default()),
+        BonsaiStorageConfig::default(),
+        24,
+    );
     let mut id_builder = BasicIdBuilder::new();
 
     let pair = (
@@ -313,5 +336,8 @@ fn clean_commit_with_retained_frontier_is_noop() {
     // Second commit has no new mutations and should keep the already-loaded frontier stable.
     bonsai_storage.commit(id_builder.new_id()).unwrap();
     assert_eq!(staged_root, bonsai_storage.root_hash(&identifier).unwrap());
-    assert_eq!(staged_root, bonsai_storage.root_hash_staged(&identifier).unwrap());
+    assert_eq!(
+        staged_root,
+        bonsai_storage.root_hash_staged(&identifier).unwrap()
+    );
 }

--- a/src/trie/iterator.rs
+++ b/src/trie/iterator.rs
@@ -228,7 +228,7 @@ impl<'a, H: StarkHash + Send + Sync, DB: BonsaiDatabase, ID: Id> MerkleTreeItera
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "rocksdb"))]
 mod tests {
     //! The tree used in this series of tests looks like this:
     //! ```

--- a/src/trie/proof.rs
+++ b/src/trie/proof.rs
@@ -219,7 +219,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "rocksdb"))]
 mod tests {
     use crate::{
         databases::{create_rocks_db, RocksDB, RocksDBConfig},

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -66,6 +66,30 @@ const RETAIN_FULL_FRONTIER_MIN_HOT_KEYS: usize = 512;
 const RETAIN_FULL_FRONTIER_MAX_NODES: usize = 50_000;
 
 #[cfg(feature = "std")]
+fn retain_full_frontier_limits() -> (usize, usize) {
+    static LIMITS: std::sync::OnceLock<(usize, usize)> = std::sync::OnceLock::new();
+    *LIMITS.get_or_init(|| {
+        let min_hot_keys = std::env::var("BONSAI_RETAIN_FULL_FRONTIER_MIN_HOT_KEYS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(RETAIN_FULL_FRONTIER_MIN_HOT_KEYS);
+        let max_nodes = std::env::var("BONSAI_RETAIN_FULL_FRONTIER_MAX_NODES")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(RETAIN_FULL_FRONTIER_MAX_NODES);
+        (min_hot_keys, max_nodes)
+    })
+}
+
+#[cfg(not(feature = "std"))]
+fn retain_full_frontier_limits() -> (usize, usize) {
+    (
+        RETAIN_FULL_FRONTIER_MIN_HOT_KEYS,
+        RETAIN_FULL_FRONTIER_MAX_NODES,
+    )
+}
+
+#[cfg(feature = "std")]
 #[derive(Default)]
 struct StagedHashCacheCell(std::sync::Mutex<Option<StagedHashComputation>>);
 
@@ -387,16 +411,15 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         };
 
         let retained_before = self.nodes.len();
-        if hot_keys.len() >= RETAIN_FULL_FRONTIER_MIN_HOT_KEYS
-            && retained_before <= RETAIN_FULL_FRONTIER_MAX_NODES
-        {
+        let (min_hot_keys, max_nodes) = retain_full_frontier_limits();
+        if hot_keys.len() >= min_hot_keys && retained_before <= max_nodes {
             log::debug!(
                 "bonsai retained frontier kept_full identifier={:?} hot_keys={} retained_nodes={} min_hot_keys={} max_nodes={}",
                 self.identifier,
                 hot_keys.len(),
                 retained_before,
-                RETAIN_FULL_FRONTIER_MIN_HOT_KEYS,
-                RETAIN_FULL_FRONTIER_MAX_NODES,
+                min_hot_keys,
+                max_nodes,
             );
             return Ok(());
         }
@@ -1200,6 +1223,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
 
         let db_loads_before = self.perf_stats.db_node_loads;
         let memory_hits_before = self.perf_stats.in_memory_node_hits;
+        stats.retained_nodes_before = self.nodes.len() as u64;
         self.mark_dirty();
         let result = match self.load_root_node(db)? {
             Some(root_id) => {
@@ -1231,6 +1255,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             .perf_stats
             .in_memory_node_hits
             .saturating_sub(memory_hits_before) as u64;
+        stats.retained_nodes_after = self.nodes.len() as u64;
         result
     }
 

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -60,6 +60,8 @@ struct StagedHashComputation {
     hashes: Vec<Felt>,
 }
 
+type BulkEntry = (BitVec, ByteVec, Felt);
+
 const RETAIN_FULL_FRONTIER_MIN_HOT_KEYS: usize = 512;
 const RETAIN_FULL_FRONTIER_MAX_NODES: usize = 50_000;
 
@@ -1072,7 +1074,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             return Ok(());
         }
 
-        let entries = self.prepare_nonzero_bulk_entries::<DB>(entries)?;
+        let entries = Self::prepare_nonzero_bulk_entries::<DB>(self.max_height, entries)?;
         let mut iter = self.iter(db);
         for (key, key_bytes, value) in entries {
             Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, true)?;
@@ -1099,23 +1101,19 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             return Ok(());
         }
 
-        let entries = self.prepare_nonzero_bulk_entries::<DB>(entries)?;
-        let mut iter = self.iter(db);
-        for (key, key_bytes, value) in entries {
-            Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, false)?;
-        }
-        Ok(())
+        let entries = Self::prepare_nonzero_bulk_entries::<DB>(self.max_height, entries)?;
+        self.set_many_nonzero_owned_assume_changed_bulk(db, &entries)
     }
 
     fn prepare_nonzero_bulk_entries<DB: BonsaiDatabase>(
-        &self,
+        max_height: u8,
         entries: Vec<(BitVec, Felt)>,
-    ) -> Result<Vec<(BitVec, ByteVec, Felt)>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<Vec<BulkEntry>, BonsaiStorageError<DB::DatabaseError>> {
         let mut prepared = Vec::with_capacity(entries.len());
         for (position, (key, value)) in entries.into_iter().enumerate() {
-            if key.len() != usize::from(self.max_height) {
+            if key.len() != usize::from(max_height) {
                 return Err(BonsaiStorageError::KeyLength {
-                    expected: usize::from(self.max_height),
+                    expected: usize::from(max_height),
                     got: key.len(),
                 });
             }
@@ -1138,6 +1136,323 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
 
         Ok(deduped)
+    }
+
+    fn set_many_nonzero_owned_assume_changed_bulk<DB: BonsaiDatabase, ID: Id>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        entries: &[BulkEntry],
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        self.mark_dirty();
+        match self.load_root_node(db)? {
+            Some(root_id) => {
+                self.bulk_update_node_assume_changed(db, root_id, &Path::default(), entries)
+            }
+            None => {
+                let root =
+                    self.bulk_build_handle_assume_changed::<DB>(&Path::default(), entries)?;
+                match root {
+                    NodeHandle::InMemory(root_id) => {
+                        self.root_node = Some(RootHandle::Loaded(root_id));
+                        Ok(())
+                    }
+                    NodeHandle::Hash(_) => Err(BonsaiStorageError::Trie(
+                        "bulk insert built a leaf root".to_string(),
+                    )),
+                }
+            }
+        }
+    }
+
+    fn bulk_update_handle_assume_changed<DB: BonsaiDatabase, ID: Id>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        handle: NodeHandle,
+        prefix: &Path,
+        entries: &[BulkEntry],
+    ) -> Result<NodeHandle, BonsaiStorageError<DB::DatabaseError>> {
+        if entries.is_empty() {
+            return Ok(handle);
+        }
+
+        if prefix.len() == usize::from(self.max_height) {
+            let (_key, key_bytes, value) = entries
+                .last()
+                .expect("bulk update handle called with non-empty entries");
+            self.cache_leaf_modified
+                .insert(key_bytes.clone(), InsertOrRemove::Insert(*value));
+            return Ok(NodeHandle::Hash(*value));
+        }
+
+        let node_id = self.load_node_handle(db, handle, prefix)?;
+        self.bulk_update_node_assume_changed(db, node_id, prefix, entries)?;
+        Ok(NodeHandle::InMemory(node_id))
+    }
+
+    fn bulk_update_node_assume_changed<DB: BonsaiDatabase, ID: Id>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        node_id: NodeKey,
+        prefix: &Path,
+        entries: &[BulkEntry],
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let node = self.get_node_mut::<DB>(node_id)?.clone();
+        match node {
+            Node::Binary(mut binary) => {
+                let height = binary.height as usize;
+                debug_assert_eq!(height, prefix.len());
+                binary.hash = None;
+
+                let split = Self::partition_by_direction(entries, height);
+                if split > 0 {
+                    let mut left_prefix = prefix.clone();
+                    left_prefix.push(false);
+                    binary.left = self.bulk_update_handle_assume_changed(
+                        db,
+                        binary.left,
+                        &left_prefix,
+                        &entries[..split],
+                    )?;
+                }
+                if split < entries.len() {
+                    let mut right_prefix = prefix.clone();
+                    right_prefix.push(true);
+                    binary.right = self.bulk_update_handle_assume_changed(
+                        db,
+                        binary.right,
+                        &right_prefix,
+                        &entries[split..],
+                    )?;
+                }
+
+                self.nodes[node_id] = Node::Binary(binary);
+            }
+            Node::Edge(mut edge) => {
+                let height = edge.height as usize;
+                debug_assert_eq!(height, prefix.len());
+                edge.hash = None;
+
+                let common_len = Self::edge_common_prefix_len(&edge, entries);
+                if common_len == edge.path.len() {
+                    let mut child_prefix = prefix.clone();
+                    child_prefix.extend_from_bitslice(&edge.path.0);
+                    edge.child = self.bulk_update_handle_assume_changed(
+                        db,
+                        edge.child,
+                        &child_prefix,
+                        entries,
+                    )?;
+                    self.nodes[node_id] = Node::Edge(edge);
+                    return Ok(());
+                }
+
+                let branch_height = height + common_len;
+                let child_height = branch_height + 1;
+                let common_path = edge.path[..common_len].to_bitvec();
+                let old_direction = Direction::from(edge.path[common_len]);
+                let old_path = edge.path[common_len + 1..].to_bitvec();
+
+                let mut old_prefix = prefix.clone();
+                old_prefix.extend_from_bitslice(&common_path);
+                old_prefix.push(bool::from(old_direction));
+
+                let old_handle = if old_path.is_empty() {
+                    edge.child
+                } else {
+                    let edge_id = self.nodes.insert(Node::Edge(EdgeNode {
+                        hash: None,
+                        height: child_height as u64,
+                        path: Path(old_path),
+                        child: edge.child,
+                    }));
+                    NodeHandle::InMemory(edge_id)
+                };
+
+                let split = Self::partition_by_direction(entries, branch_height);
+                let (left_entries, right_entries) = entries.split_at(split);
+
+                let mut left_handle = None;
+                let mut right_handle = None;
+
+                match old_direction {
+                    Direction::Left => {
+                        left_handle = Some(if left_entries.is_empty() {
+                            old_handle
+                        } else {
+                            self.bulk_update_handle_assume_changed(
+                                db,
+                                old_handle,
+                                &old_prefix,
+                                left_entries,
+                            )?
+                        });
+                    }
+                    Direction::Right => {
+                        right_handle = Some(if right_entries.is_empty() {
+                            old_handle
+                        } else {
+                            self.bulk_update_handle_assume_changed(
+                                db,
+                                old_handle,
+                                &old_prefix,
+                                right_entries,
+                            )?
+                        });
+                    }
+                }
+
+                if left_handle.is_none() && !left_entries.is_empty() {
+                    let mut left_prefix = prefix.clone();
+                    left_prefix.extend_from_bitslice(&common_path);
+                    left_prefix.push(false);
+                    left_handle = Some(
+                        self.bulk_build_handle_assume_changed::<DB>(&left_prefix, left_entries)?,
+                    );
+                }
+                if right_handle.is_none() && !right_entries.is_empty() {
+                    let mut right_prefix = prefix.clone();
+                    right_prefix.extend_from_bitslice(&common_path);
+                    right_prefix.push(true);
+                    right_handle = Some(
+                        self.bulk_build_handle_assume_changed::<DB>(&right_prefix, right_entries)?,
+                    );
+                }
+
+                let branch = Node::Binary(BinaryNode {
+                    hash: None,
+                    height: branch_height as u64,
+                    left: left_handle.ok_or_else(|| {
+                        BonsaiStorageError::Trie("bulk edge split missing left child".to_string())
+                    })?,
+                    right: right_handle.ok_or_else(|| {
+                        BonsaiStorageError::Trie("bulk edge split missing right child".to_string())
+                    })?,
+                });
+
+                self.nodes[node_id] = if common_path.is_empty() {
+                    branch
+                } else {
+                    let branch_id = self.nodes.insert(branch);
+                    Node::Edge(EdgeNode {
+                        hash: None,
+                        height: height as u64,
+                        path: Path(common_path),
+                        child: NodeHandle::InMemory(branch_id),
+                    })
+                };
+            }
+        }
+
+        Ok(())
+    }
+
+    fn bulk_build_handle_assume_changed<DB: BonsaiDatabase>(
+        &mut self,
+        prefix: &Path,
+        entries: &[BulkEntry],
+    ) -> Result<NodeHandle, BonsaiStorageError<DB::DatabaseError>> {
+        if entries.is_empty() {
+            return Err(BonsaiStorageError::Trie(
+                "bulk build called with no entries".to_string(),
+            ));
+        }
+
+        if entries.len() == 1 || prefix.len() == usize::from(self.max_height) {
+            let (key, key_bytes, value) = entries
+                .last()
+                .expect("bulk build called with non-empty entries");
+            self.cache_leaf_modified
+                .insert(key_bytes.clone(), InsertOrRemove::Insert(*value));
+
+            if prefix.len() == usize::from(self.max_height) {
+                return Ok(NodeHandle::Hash(*value));
+            }
+
+            let edge_id = self.nodes.insert(Node::Edge(EdgeNode {
+                hash: None,
+                height: prefix.len() as u64,
+                path: Path(key[prefix.len()..].to_bitvec()),
+                child: NodeHandle::Hash(*value),
+            }));
+            return Ok(NodeHandle::InMemory(edge_id));
+        }
+
+        let shared_prefix_len = Self::shared_prefix_len(entries, prefix.len());
+        if shared_prefix_len > prefix.len() {
+            let mut child_prefix = prefix.clone();
+            child_prefix.extend_from_bitslice(&entries[0].0[prefix.len()..shared_prefix_len]);
+            let child = self.bulk_build_handle_assume_changed::<DB>(&child_prefix, entries)?;
+            let edge_id = self.nodes.insert(Node::Edge(EdgeNode {
+                hash: None,
+                height: prefix.len() as u64,
+                path: Path(entries[0].0[prefix.len()..shared_prefix_len].to_bitvec()),
+                child,
+            }));
+            return Ok(NodeHandle::InMemory(edge_id));
+        }
+
+        let split = Self::partition_by_direction(entries, prefix.len());
+        if split == 0 || split == entries.len() {
+            return Err(BonsaiStorageError::Trie(
+                "bulk build could not partition entries".to_string(),
+            ));
+        }
+
+        let mut left_prefix = prefix.clone();
+        left_prefix.push(false);
+        let left = self.bulk_build_handle_assume_changed::<DB>(&left_prefix, &entries[..split])?;
+
+        let mut right_prefix = prefix.clone();
+        right_prefix.push(true);
+        let right =
+            self.bulk_build_handle_assume_changed::<DB>(&right_prefix, &entries[split..])?;
+
+        let binary_id = self.nodes.insert(Node::Binary(BinaryNode {
+            hash: None,
+            height: prefix.len() as u64,
+            left,
+            right,
+        }));
+        Ok(NodeHandle::InMemory(binary_id))
+    }
+
+    fn partition_by_direction(entries: &[BulkEntry], height: usize) -> usize {
+        entries.partition_point(|(key, _, _)| !key[height])
+    }
+
+    fn shared_prefix_len(entries: &[BulkEntry], start: usize) -> usize {
+        let first = &entries
+            .first()
+            .expect("shared prefix called with entries")
+            .0;
+        let last = &entries.last().expect("shared prefix called with entries").0;
+        let mut len = start;
+        while len < first.len() && first[len] == last[len] {
+            len += 1;
+        }
+        len
+    }
+
+    fn edge_common_prefix_len(edge: &EdgeNode, entries: &[BulkEntry]) -> usize {
+        entries
+            .iter()
+            .map(|(key, _, _)| {
+                let mut len = 0;
+                let height = edge.height as usize;
+                while len < edge.path.len()
+                    && height + len < key.len()
+                    && edge.path[len] == key[height + len]
+                {
+                    len += 1;
+                }
+                len
+            })
+            .min()
+            .expect("edge common prefix called with entries")
     }
 
     fn set_nonzero_with_key_bytes_using_iter<DB: BonsaiDatabase, ID: Id>(

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -60,6 +60,9 @@ struct StagedHashComputation {
     hashes: Vec<Felt>,
 }
 
+const RETAIN_FULL_FRONTIER_MIN_HOT_KEYS: usize = 512;
+const RETAIN_FULL_FRONTIER_MAX_NODES: usize = 50_000;
+
 #[cfg(feature = "std")]
 #[derive(Default)]
 struct StagedHashCacheCell(std::sync::Mutex<Option<StagedHashComputation>>);
@@ -382,6 +385,20 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         };
 
         let retained_before = self.nodes.len();
+        if hot_keys.len() >= RETAIN_FULL_FRONTIER_MIN_HOT_KEYS
+            && retained_before <= RETAIN_FULL_FRONTIER_MAX_NODES
+        {
+            log::debug!(
+                "bonsai retained frontier kept_full identifier={:?} hot_keys={} retained_nodes={} min_hot_keys={} max_nodes={}",
+                self.identifier,
+                hot_keys.len(),
+                retained_before,
+                RETAIN_FULL_FRONTIER_MIN_HOT_KEYS,
+                RETAIN_FULL_FRONTIER_MAX_NODES,
+            );
+            return Ok(());
+        }
+
         let mut retained_nodes = HashSet::default();
         retained_nodes.insert(root_id);
         for key in hot_keys {

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -11,7 +11,7 @@ use crate::{
     EncodeExt, HashMap, HashSet, KeyValueDB, ToString, Vec,
 };
 
-use super::iterator::MerkleTreeIterator;
+use super::iterator::{MerkleTreeIterator, NodeVisitor};
 use super::{
     merkle_node::{BinaryNode, Direction, EdgeNode, Node, NodeHandle},
     path::Path,
@@ -48,6 +48,84 @@ pub(crate) enum RootHandle {
     Loaded(NodeKey),
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+struct TreePerfStats {
+    db_node_loads: usize,
+    in_memory_node_hits: usize,
+}
+
+#[derive(Debug)]
+struct StagedHashComputation {
+    root_hash: Felt,
+    hashes: Vec<Felt>,
+}
+
+#[cfg(feature = "std")]
+#[derive(Default)]
+struct StagedHashCacheCell(std::sync::Mutex<Option<StagedHashComputation>>);
+
+#[cfg(feature = "std")]
+impl fmt::Debug for StagedHashCacheCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let has_cached_hashes = self.0.lock().map(|cache| cache.is_some()).unwrap_or(false);
+        f.debug_struct("StagedHashCacheCell")
+            .field("has_cached_hashes", &has_cached_hashes)
+            .finish()
+    }
+}
+
+#[cfg(feature = "std")]
+impl Clone for StagedHashCacheCell {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "std")]
+impl StagedHashCacheCell {
+    fn clear(&self) {
+        if let Ok(mut cache) = self.0.lock() {
+            *cache = None;
+        }
+    }
+
+    fn cached_root_hash(&self) -> Option<Felt> {
+        self.0
+            .lock()
+            .ok()
+            .and_then(|cache| cache.as_ref().map(|cached| cached.root_hash))
+    }
+
+    fn store(&self, computation: StagedHashComputation) {
+        if let Ok(mut cache) = self.0.lock() {
+            *cache = Some(computation);
+        }
+    }
+
+    fn take(&self) -> Option<StagedHashComputation> {
+        self.0.lock().ok().and_then(|mut cache| cache.take())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+#[derive(Default, Debug, Clone)]
+struct StagedHashCacheCell;
+
+#[cfg(not(feature = "std"))]
+impl StagedHashCacheCell {
+    fn clear(&self) {}
+
+    fn cached_root_hash(&self) -> Option<Felt> {
+        None
+    }
+
+    fn store(&self, _computation: StagedHashComputation) {}
+
+    fn take(&self) -> Option<StagedHashComputation> {
+        None
+    }
+}
+
 /// A Starknet binary Merkle-Patricia tree with a specific root entry-point and storage.
 ///
 /// This is used to update, mutate and access global Starknet state as well as individual contract
@@ -65,6 +143,12 @@ pub struct MerkleTree<H: StarkHash> {
     pub(crate) death_row: HashSet<TrieKey>,
     /// The list of leaves that have been modified during the current commit.
     pub(crate) cache_leaf_modified: HashMap<ByteVec, InsertOrRemove<Felt>>,
+    /// Whether this tree has staged mutations that are not yet committed.
+    dirty: bool,
+    /// Cached staged root computation so commit can reuse the exact same hash walk.
+    staged_hashes: StagedHashCacheCell,
+    /// Per-block load counters to show whether the frontier stayed hot.
+    perf_stats: TreePerfStats,
     /// The maximum height of the tree. This is an u8 because we may rely on the fact that it's less than 256 in the future for optimizations.
     pub(crate) max_height: u8,
     /// The hasher used to hash the nodes.
@@ -79,6 +163,9 @@ impl<H: StarkHash> fmt::Debug for MerkleTree<H> {
             .field("identifier", &self.identifier)
             .field("death_row", &self.death_row)
             .field("cache_leaf_modified", &self.cache_leaf_modified)
+            .field("dirty", &self.dirty)
+            .field("staged_hashes", &self.staged_hashes)
+            .field("perf_stats", &self.perf_stats)
             .finish()
     }
 }
@@ -94,6 +181,9 @@ impl<H: StarkHash> Clone for MerkleTree<H> {
             identifier: self.identifier.clone(),
             death_row: self.death_row.clone(),
             cache_leaf_modified: self.cache_leaf_modified.clone(),
+            dirty: self.dirty,
+            staged_hashes: self.staged_hashes.clone(),
+            perf_stats: self.perf_stats,
             _hasher: PhantomData,
         }
     }
@@ -109,6 +199,23 @@ enum NodeOrFelt<'a> {
     Felt(Felt),
 }
 
+struct InvalidateHashesVisitor<H>(PhantomData<H>);
+
+impl<H: StarkHash + Send + Sync> NodeVisitor<H> for InvalidateHashesVisitor<H> {
+    fn visit_node<DB: BonsaiDatabase>(
+        &mut self,
+        tree: &mut MerkleTree<H>,
+        node_id: NodeKey,
+        _prev_height: usize,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        match tree.get_node_mut::<DB>(node_id)? {
+            Node::Binary(binary_node) => binary_node.hash = None,
+            Node::Edge(edge_node) => edge_node.hash = None,
+        }
+        Ok(())
+    }
+}
+
 impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     pub fn new(identifier: ByteVec, max_height: u8) -> Self {
         Self {
@@ -117,9 +224,17 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             identifier,
             death_row: HashSet::new(),
             cache_leaf_modified: HashMap::new(),
+            dirty: false,
+            staged_hashes: Default::default(),
+            perf_stats: Default::default(),
             max_height,
             _hasher: PhantomData,
         }
+    }
+
+    fn mark_dirty(&mut self) {
+        self.dirty = true;
+        self.staged_hashes.clear();
     }
 
     /// Loads the root node or returns None if the tree is empty.
@@ -161,6 +276,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
         let node = db.get(key)?;
         let Some(node) = node else { return Ok(None) };
+        self.perf_stats.db_node_loads += 1;
 
         let node = Node::decode(&mut node.as_slice())?;
         let key = self.nodes.insert(node);
@@ -197,7 +313,10 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 };
                 Ok(node_key)
             }
-            NodeHandle::InMemory(node_key) => Ok(node_key),
+            NodeHandle::InMemory(node_key) => {
+                self.perf_stats.in_memory_node_hits += 1;
+                Ok(node_key)
+            }
         }
     }
 
@@ -292,30 +411,37 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     #[allow(clippy::type_complexity)]
     pub(crate) fn get_updates<DB: BonsaiDatabase>(
         &mut self,
-    ) -> Result<
-        impl Iterator<Item = (TrieKey, InsertOrRemove<ByteVec>)>,
-        BonsaiStorageError<DB::DatabaseError>,
-    > {
+    ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>> {
+        let dirty_before_commit = self.dirty;
         let mut updates = HashMap::new();
         for node_key in mem::take(&mut self.death_row) {
             updates.insert(node_key, InsertOrRemove::Remove);
         }
 
-        if let Some(RootHandle::Loaded(node_id)) = &self.root_node {
-            // compute hashes
-            let mut hashes = vec![];
-            self.compute_root_hash::<DB>(&mut hashes)?;
+        let mut used_staged_hash_cache = false;
+        let mut precomputed_hashes = 0usize;
+        if self.dirty {
+            if let Some(RootHandle::Loaded(node_id)) = self.root_node {
+                let hashes = if let Some(staged) = self.staged_hashes.take() {
+                    used_staged_hash_cache = true;
+                    precomputed_hashes = staged.hashes.len();
+                    staged.hashes
+                } else {
+                    let mut hashes = vec![];
+                    self.compute_root_hash::<DB>(&mut hashes)?;
+                    precomputed_hashes = hashes.len();
+                    hashes
+                };
 
-            // commit the tree
-            self.commit_subtree::<DB>(
-                &mut updates,
-                *node_id,
-                Path::default(),
-                &mut hashes.into_iter(),
-            )?;
+                self.commit_subtree_cached::<DB>(
+                    &mut updates,
+                    node_id,
+                    Path::default(),
+                    &mut hashes.into_iter(),
+                )?;
+            }
+            self.dirty = false;
         }
-
-        self.root_node = None; // unloaded
 
         for (key, value) in mem::take(&mut self.cache_leaf_modified) {
             updates.insert(
@@ -326,10 +452,22 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 },
             );
         }
-        #[cfg(test)]
-        self.assert_empty(); // we should have visited the whole tree
+        log::debug!(
+            "bonsai commit identifier={:?} dirty_before_commit={} used_staged_hash_cache={} precomputed_hashes={} db_node_loads={} in_memory_node_hits={} retained_nodes={} root_loaded={} flat_changes={} trie_updates={}",
+            self.identifier,
+            dirty_before_commit,
+            used_staged_hash_cache,
+            precomputed_hashes,
+            self.perf_stats.db_node_loads,
+            self.perf_stats.in_memory_node_hits,
+            self.nodes.len(),
+            matches!(self.root_node, Some(RootHandle::Loaded(_))),
+            updates.keys().filter(|key| matches!(key, TrieKey::Flat(_))).count(),
+            updates.keys().filter(|key| matches!(key, TrieKey::Trie(_))).count(),
+        );
+        self.perf_stats = Default::default();
 
-        Ok(updates.into_iter())
+        Ok(updates)
     }
 
     // Commit a single merkle tree
@@ -386,10 +524,33 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         &self,
         db: &KeyValueDB<DB, ID>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        if !self.dirty {
+            return self.root_hash(db);
+        }
+
+        if let Some(root_hash) = self.staged_hashes.cached_root_hash() {
+            log::debug!(
+                "bonsai staged root cache hit identifier={:?} retained_nodes={}",
+                self.identifier,
+                self.nodes.len(),
+            );
+            return Ok(root_hash);
+        }
+
         match &self.root_node {
             Some(RootHandle::Loaded(_)) => {
                 let mut hashes = vec![];
-                self.compute_root_hash::<DB>(&mut hashes)
+                let root_hash = self.compute_root_hash::<DB>(&mut hashes)?;
+                log::debug!(
+                    "bonsai staged root computed identifier={:?} precomputed_hashes={} retained_nodes={} db_node_loads={} in_memory_node_hits={}",
+                    self.identifier,
+                    hashes.len(),
+                    self.nodes.len(),
+                    self.perf_stats.db_node_loads,
+                    self.perf_stats.in_memory_node_hits,
+                );
+                self.staged_hashes.store(StagedHashComputation { root_hash, hashes });
+                Ok(root_hash)
             }
             Some(RootHandle::Empty) => Ok(Felt::ZERO),
             None => self.root_hash(db),
@@ -514,60 +675,73 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     /// # Panics
     ///
     /// Panics if the precomputed `hashes` do not match the length of the modified subtree.
-    fn commit_subtree<DB: BonsaiDatabase>(
+    fn commit_subtree_cached<DB: BonsaiDatabase>(
         &mut self,
         updates: &mut HashMap<TrieKey, InsertOrRemove<ByteVec>>,
         node_id: NodeKey,
         path: Path,
         hashes: &mut impl Iterator<Item = Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
-        match self.nodes.remove(node_id).ok_or(BonsaiStorageError::Trie(
+        match self.nodes.get(node_id).cloned().ok_or(BonsaiStorageError::Trie(
             "Couldn't fetch node in the temporary storage".to_string(),
         ))? {
-            Node::Binary(mut binary) => {
+            Node::Binary(binary) => {
                 let left_path = path.new_with_direction(Direction::Left);
                 let left_hash = match binary.left {
                     NodeHandle::Hash(left_hash) => left_hash,
                     NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree::<DB>(updates, node_id, left_path, hashes)?
+                        self.commit_subtree_cached::<DB>(updates, node_id, left_path, hashes)?
                     }
                 };
                 let right_path = path.new_with_direction(Direction::Right);
                 let right_hash = match binary.right {
                     NodeHandle::Hash(right_hash) => right_hash,
                     NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree::<DB>(updates, node_id, right_path, hashes)?
+                        self.commit_subtree_cached::<DB>(updates, node_id, right_path, hashes)?
                     }
                 };
 
                 let hash = hashes.next().expect("mismatched hash state");
 
-                binary.hash = Some(hash);
-                binary.left = NodeHandle::Hash(left_hash);
-                binary.right = NodeHandle::Hash(right_hash);
+                match self.get_node_mut::<DB>(node_id)? {
+                    Node::Binary(binary_node) => binary_node.hash = Some(hash),
+                    Node::Edge(_) => unreachable!("node changed type while committing"),
+                }
+
+                let mut persisted_binary = binary;
+                persisted_binary.hash = Some(hash);
+                persisted_binary.left = NodeHandle::Hash(left_hash);
+                persisted_binary.right = NodeHandle::Hash(right_hash);
                 let key_bytes: ByteVec = path.into();
                 updates.insert(
                     TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
-                    InsertOrRemove::Insert(Node::Binary(binary).encode_bytevec()),
+                    InsertOrRemove::Insert(Node::Binary(persisted_binary).encode_bytevec()),
                 );
                 Ok(hash)
             }
-            Node::Edge(mut edge) => {
+            Node::Edge(edge) => {
                 let mut child_path = path.clone();
                 child_path.0.extend(&edge.path.0);
                 let child_hash = match edge.child {
                     NodeHandle::Hash(right_hash) => right_hash,
                     NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree::<DB>(updates, node_id, child_path, hashes)?
+                        self.commit_subtree_cached::<DB>(updates, node_id, child_path, hashes)?
                     }
                 };
                 let hash = hashes.next().expect("mismatched hash state");
-                edge.hash = Some(hash);
-                edge.child = NodeHandle::Hash(child_hash);
+
+                match self.get_node_mut::<DB>(node_id)? {
+                    Node::Edge(edge_node) => edge_node.hash = Some(hash),
+                    Node::Binary(_) => unreachable!("node changed type while committing"),
+                }
+
+                let mut persisted_edge = edge;
+                persisted_edge.hash = Some(hash);
+                persisted_edge.child = NodeHandle::Hash(child_hash);
                 let key_bytes: ByteVec = path.into();
                 updates.insert(
                     TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
-                    InsertOrRemove::Insert(Node::Edge(edge).encode_bytevec()),
+                    InsertOrRemove::Insert(Node::Edge(persisted_edge).encode_bytevec()),
                 );
                 Ok(hash)
             }
@@ -618,8 +792,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             }
         }
 
+        self.mark_dirty();
         let mut iter = self.iter(db);
-        iter.seek_to(key)?;
+        iter.traverse_to(&mut InvalidateHashesVisitor(PhantomData), key)?;
         log::trace!("Iter is {:?}", iter);
         let path_nodes = iter.current_nodes_heights;
 
@@ -825,8 +1000,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
         leaf_entry.insert(InsertOrRemove::Remove);
 
+        self.mark_dirty();
         let mut iter = self.iter(db);
-        iter.seek_to(key)?;
+        iter.traverse_to(&mut InvalidateHashesVisitor(PhantomData), key)?;
         log::trace!("Iter is {:?}", iter);
         let mut path_nodes = iter.current_nodes_heights;
 

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -1072,9 +1072,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             return Ok(());
         }
 
+        let entries = self.prepare_nonzero_bulk_entries::<DB>(entries)?;
         let mut iter = self.iter(db);
-        for (key, value) in entries {
-            let key_bytes = bitvec_to_bytes(&key);
+        for (key, key_bytes, value) in entries {
             Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, true)?;
         }
         Ok(())
@@ -1099,12 +1099,45 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             return Ok(());
         }
 
+        let entries = self.prepare_nonzero_bulk_entries::<DB>(entries)?;
         let mut iter = self.iter(db);
-        for (key, value) in entries {
-            let key_bytes = bitvec_to_bytes(&key);
+        for (key, key_bytes, value) in entries {
             Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, false)?;
         }
         Ok(())
+    }
+
+    fn prepare_nonzero_bulk_entries<DB: BonsaiDatabase>(
+        &self,
+        entries: Vec<(BitVec, Felt)>,
+    ) -> Result<Vec<(BitVec, ByteVec, Felt)>, BonsaiStorageError<DB::DatabaseError>> {
+        let mut prepared = Vec::with_capacity(entries.len());
+        for (position, (key, value)) in entries.into_iter().enumerate() {
+            if key.len() != usize::from(self.max_height) {
+                return Err(BonsaiStorageError::KeyLength {
+                    expected: usize::from(self.max_height),
+                    got: key.len(),
+                });
+            }
+            let key_bytes = bitvec_to_bytes(&key);
+            prepared.push((key_bytes, position, key, value));
+        }
+
+        prepared.sort_unstable_by(|lhs, rhs| lhs.0.cmp(&rhs.0).then(lhs.1.cmp(&rhs.1)));
+
+        let mut deduped = Vec::with_capacity(prepared.len());
+        for (key_bytes, _position, key, value) in prepared {
+            if let Some((last_key, last_key_bytes, last_value)) = deduped.last_mut() {
+                if *last_key_bytes == key_bytes {
+                    *last_key = key;
+                    *last_value = value;
+                    continue;
+                }
+            }
+            deduped.push((key, key_bytes, value));
+        }
+
+        Ok(deduped)
     }
 
     fn set_nonzero_with_key_bytes_using_iter<DB: BonsaiDatabase, ID: Id>(

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -1063,9 +1063,19 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         ID: Id,
         I: IntoIterator<Item = (BitVec, Felt)>,
     {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        if entries.iter().any(|(_, value)| *value == Felt::ZERO) {
+            for (key, value) in entries {
+                let key_bytes = bitvec_to_bytes(&key);
+                self.set_with_key_bytes(db, &key, key_bytes, value, true)?;
+            }
+            return Ok(());
+        }
+
+        let mut iter = self.iter(db);
         for (key, value) in entries {
             let key_bytes = bitvec_to_bytes(&key);
-            self.set_with_key_bytes(db, &key, key_bytes, value, true)?;
+            Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, true)?;
         }
         Ok(())
     }
@@ -1080,11 +1090,182 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         ID: Id,
         I: IntoIterator<Item = (BitVec, Felt)>,
     {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        if entries.iter().any(|(_, value)| *value == Felt::ZERO) {
+            for (key, value) in entries {
+                let key_bytes = bitvec_to_bytes(&key);
+                self.set_with_key_bytes(db, &key, key_bytes, value, false)?;
+            }
+            return Ok(());
+        }
+
+        let mut iter = self.iter(db);
         for (key, value) in entries {
             let key_bytes = bitvec_to_bytes(&key);
-            self.set_with_key_bytes(db, &key, key_bytes, value, false)?;
+            Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, false)?;
         }
         Ok(())
+    }
+
+    fn set_nonzero_with_key_bytes_using_iter<DB: BonsaiDatabase, ID: Id>(
+        iter: &mut MerkleTreeIterator<'_, H, DB, ID>,
+        key: &BitSlice,
+        key_bytes: ByteVec,
+        value: Felt,
+        check_committed_value: bool,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        debug_assert_ne!(value, Felt::ZERO);
+        if key.len() != usize::from(iter.tree.max_height) {
+            return Err(BonsaiStorageError::KeyLength {
+                expected: usize::from(iter.tree.max_height),
+                got: key.len(),
+            });
+        }
+        log::trace!("key_bytes: {:?}", key_bytes);
+        let has_staged_override = match iter.tree.cache_leaf_modified.get(&key_bytes) {
+            Some(InsertOrRemove::Insert(staged_value)) if *staged_value == value => return Ok(()),
+            Some(_) => true,
+            None => false,
+        };
+
+        if check_committed_value && !has_staged_override {
+            if let Some(value_db) = iter.db.get(&TrieKey::new(
+                &iter.tree.identifier,
+                TrieKeyType::Flat,
+                &key_bytes,
+            ))? {
+                if value == Felt::decode(&mut value_db.as_slice()).unwrap() {
+                    return Ok(());
+                }
+            }
+        }
+
+        iter.tree.mark_dirty();
+        iter.traverse_to(&mut InvalidateHashesVisitor(PhantomData), key)?;
+        log::trace!("Iter is {:?}", iter);
+        let path_nodes = iter.current_nodes_heights.clone();
+
+        log::trace!("preload nodes: {:?}", path_nodes);
+        use Node::*;
+        match path_nodes.last() {
+            Some((node_id, _)) => {
+                let tree = &mut *iter.tree;
+                let mut node = tree.get_node_mut::<DB>(*node_id)?.clone();
+                match &mut node {
+                    Edge(edge) => {
+                        let common = edge.common_path(key);
+                        let branch_height = edge.height as usize + common.len();
+                        if branch_height == key.len() {
+                            edge.child = NodeHandle::Hash(value);
+                            log::trace!("change val: {:?} => {:#x}", key_bytes, value);
+                            tree.cache_leaf_modified
+                                .insert(key_bytes, InsertOrRemove::Insert(value));
+                            tree.nodes[*node_id] = node;
+                            return Ok(());
+                        }
+
+                        let child_height = branch_height + 1;
+                        let new_path = key[child_height..].to_bitvec();
+                        let old_path = edge.path[common.len() + 1..].to_bitvec();
+
+                        log::trace!(
+                            "cache_leaf_modified insert: {:?} => {:#x}",
+                            key_bytes,
+                            value
+                        );
+                        tree.cache_leaf_modified
+                            .insert(key_bytes, InsertOrRemove::Insert(value));
+
+                        let new = if new_path.is_empty() {
+                            NodeHandle::Hash(value)
+                        } else {
+                            let edge_id = tree.nodes.insert(Node::Edge(EdgeNode {
+                                hash: None,
+                                height: child_height as u64,
+                                path: Path(new_path),
+                                child: NodeHandle::Hash(value),
+                            }));
+                            NodeHandle::InMemory(edge_id)
+                        };
+
+                        let old = if old_path.is_empty() {
+                            edge.child
+                        } else {
+                            let edge_id = tree.nodes.insert(Node::Edge(EdgeNode {
+                                hash: None,
+                                height: child_height as u64,
+                                path: Path(old_path),
+                                child: edge.child,
+                            }));
+                            NodeHandle::InMemory(edge_id)
+                        };
+
+                        let new_direction = Direction::from(key[branch_height]);
+                        let (left, right) = match new_direction {
+                            Direction::Left => (new, old),
+                            Direction::Right => (old, new),
+                        };
+
+                        let branch = Node::Binary(BinaryNode {
+                            hash: None,
+                            height: branch_height as u64,
+                            left,
+                            right,
+                        });
+
+                        let new_node = if common.is_empty() {
+                            branch
+                        } else {
+                            let branch_id = tree.nodes.insert(branch);
+                            Node::Edge(EdgeNode {
+                                hash: None,
+                                height: edge.height,
+                                path: Path(common.to_bitvec()),
+                                child: NodeHandle::InMemory(branch_id),
+                            })
+                        };
+                        let key_bytes = bitslice_to_bytes(&key[..edge.height as usize]);
+                        log::trace!("2 death row add ({:?})", key_bytes);
+                        tree.death_row.insert(TrieKey::Trie(key_bytes));
+                        node = new_node;
+                    }
+                    Binary(binary) => {
+                        let child_height = binary.height + 1;
+
+                        if child_height as usize == key.len() {
+                            let direction = Direction::from(key[binary.height as usize]);
+                            match direction {
+                                Direction::Left => binary.left = NodeHandle::Hash(value),
+                                Direction::Right => binary.right = NodeHandle::Hash(value),
+                            };
+                            tree.cache_leaf_modified
+                                .insert(key_bytes, InsertOrRemove::Insert(value));
+                        }
+                    }
+                };
+
+                tree.nodes[*node_id] = node;
+                Ok(())
+            }
+            None => {
+                let edge = Node::Edge(EdgeNode {
+                    hash: None,
+                    height: 0,
+                    path: Path(key.to_bitvec()),
+                    child: NodeHandle::Hash(value),
+                });
+                let node_id = iter.tree.nodes.insert(edge);
+                iter.tree.root_node = Some(RootHandle::Loaded(node_id));
+                iter.current_path = Path(key.to_bitvec());
+                iter.current_nodes_heights.clear();
+                iter.current_nodes_heights.push((node_id, 0));
+
+                iter.tree
+                    .cache_leaf_modified
+                    .insert(key_bytes, InsertOrRemove::Insert(value));
+                Ok(())
+            }
+        }
     }
 
     fn set_with_key_bytes<DB: BonsaiDatabase, ID: Id>(

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -67,7 +67,7 @@ struct StagedHashCacheCell(std::sync::Mutex<Option<StagedHashComputation>>);
 #[cfg(feature = "std")]
 impl fmt::Debug for StagedHashCacheCell {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let has_cached_hashes = self.0.lock().map(|cache| cache.is_some()).unwrap_or(false);
+        let has_cached_hashes = self.lock_cache().is_some();
         f.debug_struct("StagedHashCacheCell")
             .field("has_cached_hashes", &has_cached_hashes)
             .finish()
@@ -83,27 +83,27 @@ impl Clone for StagedHashCacheCell {
 
 #[cfg(feature = "std")]
 impl StagedHashCacheCell {
+    fn lock_cache(&self) -> std::sync::MutexGuard<'_, Option<StagedHashComputation>> {
+        self.0.lock().unwrap_or_else(|poisoned| {
+            log::warn!("recovering poisoned staged hash cache lock");
+            poisoned.into_inner()
+        })
+    }
+
     fn clear(&self) {
-        if let Ok(mut cache) = self.0.lock() {
-            *cache = None;
-        }
+        *self.lock_cache() = None;
     }
 
     fn cached_root_hash(&self) -> Option<Felt> {
-        self.0
-            .lock()
-            .ok()
-            .and_then(|cache| cache.as_ref().map(|cached| cached.root_hash))
+        self.lock_cache().as_ref().map(|cached| cached.root_hash)
     }
 
     fn store(&self, computation: StagedHashComputation) {
-        if let Ok(mut cache) = self.0.lock() {
-            *cache = Some(computation);
-        }
+        *self.lock_cache() = Some(computation);
     }
 
     fn take(&self) -> Option<StagedHashComputation> {
-        self.0.lock().ok().and_then(|mut cache| cache.take())
+        self.lock_cache().take()
     }
 }
 
@@ -235,6 +235,179 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     fn mark_dirty(&mut self) {
         self.dirty = true;
         self.staged_hashes.clear();
+    }
+
+    fn in_memory_node_hash<DB: BonsaiDatabase>(
+        &self,
+        node_id: NodeKey,
+    ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        self.nodes
+            .get(node_id)
+            .and_then(Node::get_hash)
+            .ok_or_else(|| {
+                BonsaiStorageError::Trie(format!(
+                    "missing committed hash for retained node {node_id:?}"
+                ))
+            })
+    }
+
+    fn mark_recent_frontier_nodes<DB: BonsaiDatabase>(
+        &self,
+        retained_nodes: &mut HashSet<NodeKey>,
+        node_id: NodeKey,
+        key: &BitSlice,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let node = self.nodes.get(node_id).ok_or_else(|| {
+            BonsaiStorageError::Trie(format!("Dangling in-memory node key: {node_id:?}"))
+        })?;
+        retained_nodes.insert(node_id);
+
+        match node {
+            Node::Binary(binary) => {
+                let height = binary.height as usize;
+                if height >= key.len() {
+                    return Ok(());
+                }
+
+                if let NodeHandle::InMemory(child_id) =
+                    binary.get_child(Direction::from(key[height]))
+                {
+                    self.mark_recent_frontier_nodes::<DB>(retained_nodes, child_id, key)?;
+                }
+            }
+            Node::Edge(edge) => {
+                let height = edge.height as usize;
+                if height >= key.len() {
+                    return Ok(());
+                }
+
+                let key_suffix = &key[height..];
+                let common_len = key_suffix
+                    .iter()
+                    .zip(edge.path.0.iter())
+                    .take_while(|(lhs, rhs)| lhs == rhs)
+                    .count();
+                if common_len != edge.path.len() {
+                    return Ok(());
+                }
+
+                if let NodeHandle::InMemory(child_id) = edge.child {
+                    self.mark_recent_frontier_nodes::<DB>(retained_nodes, child_id, key)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn retain_child_handle<DB: BonsaiDatabase>(
+        &self,
+        handle: NodeHandle,
+        retained_nodes: &HashSet<NodeKey>,
+        remapped_nodes: &mut HashMap<NodeKey, NodeKey>,
+        new_nodes: &mut SlotMap<NodeKey, Node>,
+    ) -> Result<NodeHandle, BonsaiStorageError<DB::DatabaseError>> {
+        match handle {
+            NodeHandle::Hash(hash) => Ok(NodeHandle::Hash(hash)),
+            NodeHandle::InMemory(node_id) if retained_nodes.contains(&node_id) => {
+                Ok(NodeHandle::InMemory(self.rebuild_retained_frontier::<DB>(
+                    node_id,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?))
+            }
+            NodeHandle::InMemory(node_id) => {
+                Ok(NodeHandle::Hash(self.in_memory_node_hash::<DB>(node_id)?))
+            }
+        }
+    }
+
+    fn rebuild_retained_frontier<DB: BonsaiDatabase>(
+        &self,
+        node_id: NodeKey,
+        retained_nodes: &HashSet<NodeKey>,
+        remapped_nodes: &mut HashMap<NodeKey, NodeKey>,
+        new_nodes: &mut SlotMap<NodeKey, Node>,
+    ) -> Result<NodeKey, BonsaiStorageError<DB::DatabaseError>> {
+        if let Some(remapped_id) = remapped_nodes.get(&node_id).copied() {
+            return Ok(remapped_id);
+        }
+
+        let mut node = self.nodes.get(node_id).cloned().ok_or_else(|| {
+            BonsaiStorageError::Trie(format!("Dangling in-memory node key: {node_id:?}"))
+        })?;
+
+        match &mut node {
+            Node::Binary(binary) => {
+                binary.left = self.retain_child_handle::<DB>(
+                    binary.left,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?;
+                binary.right = self.retain_child_handle::<DB>(
+                    binary.right,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?;
+            }
+            Node::Edge(edge) => {
+                edge.child = self.retain_child_handle::<DB>(
+                    edge.child,
+                    retained_nodes,
+                    remapped_nodes,
+                    new_nodes,
+                )?;
+            }
+        }
+
+        let remapped_id = new_nodes.insert(node);
+        remapped_nodes.insert(node_id, remapped_id);
+        Ok(remapped_id)
+    }
+
+    fn retain_recent_frontier<DB: BonsaiDatabase>(
+        &mut self,
+        hot_keys: &[ByteVec],
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let Some(root_handle) = self.root_node else {
+            self.nodes.clear();
+            return Ok(());
+        };
+        let RootHandle::Loaded(root_id) = root_handle else {
+            self.nodes.clear();
+            return Ok(());
+        };
+
+        let retained_before = self.nodes.len();
+        let mut retained_nodes = HashSet::default();
+        retained_nodes.insert(root_id);
+        for key in hot_keys {
+            self.mark_recent_frontier_nodes::<DB>(&mut retained_nodes, root_id, hot_key_bits(key))?;
+        }
+
+        let mut remapped_nodes = HashMap::default();
+        let mut new_nodes = SlotMap::default();
+        let new_root = self.rebuild_retained_frontier::<DB>(
+            root_id,
+            &retained_nodes,
+            &mut remapped_nodes,
+            &mut new_nodes,
+        )?;
+
+        self.nodes = new_nodes;
+        self.root_node = Some(RootHandle::Loaded(new_root));
+        log::debug!(
+            "bonsai retained frontier compacted identifier={:?} hot_keys={} retained_before={} retained_after={}",
+            self.identifier,
+            hot_keys.len(),
+            retained_before,
+            self.nodes.len(),
+        );
+
+        Ok(())
     }
 
     /// Loads the root node or returns None if the tree is empty.
@@ -414,6 +587,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>>
     {
         let dirty_before_commit = self.dirty;
+        let hot_keys = self.cache_leaf_modified.keys().cloned().collect::<Vec<_>>();
         let mut updates = HashMap::new();
         for node_key in mem::take(&mut self.death_row) {
             updates.insert(node_key, InsertOrRemove::Remove);
@@ -442,6 +616,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 )?;
             }
             self.dirty = false;
+            self.retain_recent_frontier::<DB>(&hot_keys)?;
         }
 
         for (key, value) in mem::take(&mut self.cache_leaf_modified) {
@@ -769,9 +944,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         if value == Felt::ZERO {
             return self.delete_leaf(db, key);
         }
-        if key.len() != self.max_height as _ {
+        if key.len() != usize::from(self.max_height) {
             return Err(BonsaiStorageError::KeyLength {
-                expected: self.max_height as _,
+                expected: usize::from(self.max_height),
                 got: key.len(),
             });
         }
@@ -967,9 +1142,9 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         db: &KeyValueDB<DB, ID>,
         key: &BitSlice,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
-        if key.len() != self.max_height as _ {
+        if key.len() != usize::from(self.max_height) {
             return Err(BonsaiStorageError::KeyLength {
-                expected: self.max_height as _,
+                expected: usize::from(self.max_height),
                 got: key.len(),
             });
         }
@@ -1329,4 +1504,123 @@ pub(crate) fn bitslice_to_bytes(bitslice: &BitSlice) -> ByteVec {
 
 pub(crate) fn bytes_to_bitvec(bytes: &[u8]) -> BitVec {
     BitSlice::from_slice(&bytes[1..]).to_bitvec()
+}
+
+fn hot_key_bits(key: &[u8]) -> &BitSlice {
+    let Some((&bit_len, raw_bits)) = key.split_first() else {
+        return BitSlice::empty();
+    };
+    let bits = BitSlice::from_slice(raw_bits);
+    &bits[..usize::from(bit_len).min(bits.len())]
+}
+
+#[cfg(all(test, feature = "std"))]
+mod staged_hash_cache_tests {
+    use super::{Node, NodeHandle, RootHandle, StagedHashCacheCell, StagedHashComputation};
+    use crate::{
+        databases::HashMapDb,
+        id::{BasicId, BasicIdBuilder},
+        BitVec, BonsaiStorage, BonsaiStorageConfig,
+    };
+    use starknet_types_core::felt::Felt;
+    use starknet_types_core::hash::Pedersen;
+
+    fn retained_tree<'a>(
+        storage: &'a BonsaiStorage<BasicId, HashMapDb<BasicId>, Pedersen>,
+        identifier: &'a [u8],
+    ) -> &'a super::MerkleTree<Pedersen> {
+        storage.tries.trees.get(identifier).unwrap()
+    }
+
+    #[test]
+    fn staged_hash_cache_recovers_from_poison() {
+        let cache = StagedHashCacheCell::default();
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = cache.0.lock().unwrap();
+            panic!("poison staged hash cache");
+        }));
+
+        cache.store(StagedHashComputation {
+            root_hash: Felt::ONE,
+            hashes: vec![Felt::TWO],
+        });
+        assert_eq!(cache.cached_root_hash(), Some(Felt::ONE));
+        assert_eq!(
+            cache.take().map(|cached| cached.hashes),
+            Some(vec![Felt::TWO])
+        );
+    }
+
+    #[test]
+    fn retained_frontier_prunes_unmodified_branch_after_commit() {
+        let identifier = vec![];
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        bonsai_storage
+            .insert(
+                &identifier,
+                &BitVec::from_vec(vec![0b0000_0000]),
+                &Felt::from_hex("0x11").unwrap(),
+            )
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        bonsai_storage
+            .insert(
+                &identifier,
+                &BitVec::from_vec(vec![0b1000_0000]),
+                &Felt::from_hex("0x22").unwrap(),
+            )
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        let tree = retained_tree(&bonsai_storage, &identifier);
+        let root_id = match tree.root_node {
+            Some(RootHandle::Loaded(root_id)) => root_id,
+            other => panic!("expected loaded root, got {other:?}"),
+        };
+        let root = tree.nodes.get(root_id).unwrap();
+        let Node::Binary(root) = root else {
+            panic!("expected binary root after inserting divergent keys");
+        };
+
+        assert_eq!(tree.nodes.len(), 2);
+        assert!(matches!(root.left, NodeHandle::Hash(_)));
+        assert!(matches!(root.right, NodeHandle::InMemory(_)));
+    }
+
+    #[test]
+    fn retained_frontier_stays_bounded_across_disjoint_commits() {
+        let identifier = vec![];
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        for (key, value) in [
+            (vec![0b0000_0000], Felt::from_hex("0x11").unwrap()),
+            (vec![0b1000_0000], Felt::from_hex("0x22").unwrap()),
+            (vec![0b1100_0000], Felt::from_hex("0x33").unwrap()),
+        ] {
+            bonsai_storage
+                .insert(&identifier, &BitVec::from_vec(key), &value)
+                .unwrap();
+            bonsai_storage.commit(id_builder.new_id()).unwrap();
+        }
+
+        let tree = retained_tree(&bonsai_storage, &identifier);
+        assert!(
+            tree.nodes.len() <= 4,
+            "retained frontier should stay small for a single recently touched branch, got {} nodes",
+            tree.nodes.len()
+        );
+    }
 }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -1053,6 +1053,23 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         self.set_with_key_bytes(db, &key, key_bytes, value)
     }
 
+    pub fn set_many_owned<DB, ID, I>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        entries: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        DB: BonsaiDatabase,
+        ID: Id,
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        for (key, value) in entries {
+            let key_bytes = bitvec_to_bytes(&key);
+            self.set_with_key_bytes(db, &key, key_bytes, value)?;
+        }
+        Ok(())
+    }
+
     fn set_with_key_bytes<DB: BonsaiDatabase, ID: Id>(
         &mut self,
         db: &KeyValueDB<DB, ID>,

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -636,14 +636,40 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             self.retain_recent_frontier::<DB>(&hot_keys)?;
         }
 
-        for (key, value) in mem::take(&mut self.cache_leaf_modified) {
-            updates.insert(
-                TrieKey::new(&self.identifier, TrieKeyType::Flat, &key),
-                match value {
-                    InsertOrRemove::Insert(value) => InsertOrRemove::Insert(value.encode_bytevec()),
-                    InsertOrRemove::Remove => InsertOrRemove::Remove,
-                },
-            );
+        #[cfg(feature = "std")]
+        {
+            use rayon::prelude::*;
+
+            let leaf_updates: Vec<_> = mem::take(&mut self.cache_leaf_modified)
+                .into_par_iter()
+                .map(|(key, value)| {
+                    (
+                        TrieKey::new(&self.identifier, TrieKeyType::Flat, &key),
+                        match value {
+                            InsertOrRemove::Insert(value) => {
+                                InsertOrRemove::Insert(value.encode_bytevec())
+                            }
+                            InsertOrRemove::Remove => InsertOrRemove::Remove,
+                        },
+                    )
+                })
+                .collect();
+            updates.extend(leaf_updates);
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            for (key, value) in mem::take(&mut self.cache_leaf_modified) {
+                updates.insert(
+                    TrieKey::new(&self.identifier, TrieKeyType::Flat, &key),
+                    match value {
+                        InsertOrRemove::Insert(value) => {
+                            InsertOrRemove::Insert(value.encode_bytevec())
+                        }
+                        InsertOrRemove::Remove => InsertOrRemove::Remove,
+                    },
+                );
+            }
         }
         log::debug!(
             "bonsai commit identifier={:?} dirty_before_commit={} used_staged_hash_cache={} precomputed_hashes={} db_node_loads={} in_memory_node_hits={} retained_nodes={} root_loaded={} flat_changes={} trie_updates={}",
@@ -880,6 +906,50 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         path: Path,
         hashes: &mut impl Iterator<Item = Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        let mut nodes_to_serialize = Vec::new();
+        let root_hash = self.collect_nodes_for_commit_cached::<DB>(
+            node_id,
+            path,
+            hashes,
+            &mut nodes_to_serialize,
+        )?;
+
+        #[cfg(feature = "std")]
+        {
+            use rayon::prelude::*;
+
+            let serialized: Vec<_> = nodes_to_serialize
+                .into_par_iter()
+                .map(|(key_bytes, node)| {
+                    (
+                        TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
+                        InsertOrRemove::Insert(node.encode_bytevec()),
+                    )
+                })
+                .collect();
+            updates.extend(serialized);
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            for (key_bytes, node) in nodes_to_serialize {
+                updates.insert(
+                    TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
+                    InsertOrRemove::Insert(node.encode_bytevec()),
+                );
+            }
+        }
+
+        Ok(root_hash)
+    }
+
+    fn collect_nodes_for_commit_cached<DB: BonsaiDatabase>(
+        &mut self,
+        node_id: NodeKey,
+        path: Path,
+        hashes: &mut impl Iterator<Item = Felt>,
+        nodes_to_serialize: &mut Vec<(ByteVec, Node)>,
+    ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
         if let Some(hash) = self.nodes.get(node_id).and_then(Node::get_hash) {
             return Ok(hash);
         }
@@ -895,16 +965,22 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 let left_path = path.new_with_direction(Direction::Left);
                 let left_hash = match binary.left {
                     NodeHandle::Hash(left_hash) => left_hash,
-                    NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree_cached::<DB>(updates, node_id, left_path, hashes)?
-                    }
+                    NodeHandle::InMemory(node_id) => self.collect_nodes_for_commit_cached::<DB>(
+                        node_id,
+                        left_path,
+                        hashes,
+                        nodes_to_serialize,
+                    )?,
                 };
                 let right_path = path.new_with_direction(Direction::Right);
                 let right_hash = match binary.right {
                     NodeHandle::Hash(right_hash) => right_hash,
-                    NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree_cached::<DB>(updates, node_id, right_path, hashes)?
-                    }
+                    NodeHandle::InMemory(node_id) => self.collect_nodes_for_commit_cached::<DB>(
+                        node_id,
+                        right_path,
+                        hashes,
+                        nodes_to_serialize,
+                    )?,
                 };
 
                 let hash = hashes.next().expect("mismatched hash state");
@@ -919,10 +995,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 persisted_binary.left = NodeHandle::Hash(left_hash);
                 persisted_binary.right = NodeHandle::Hash(right_hash);
                 let key_bytes: ByteVec = path.into();
-                updates.insert(
-                    TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
-                    InsertOrRemove::Insert(Node::Binary(persisted_binary).encode_bytevec()),
-                );
+                nodes_to_serialize.push((key_bytes, Node::Binary(persisted_binary)));
                 Ok(hash)
             }
             Node::Edge(edge) => {
@@ -930,9 +1003,12 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 child_path.0.extend(&edge.path.0);
                 let child_hash = match edge.child {
                     NodeHandle::Hash(right_hash) => right_hash,
-                    NodeHandle::InMemory(node_id) => {
-                        self.commit_subtree_cached::<DB>(updates, node_id, child_path, hashes)?
-                    }
+                    NodeHandle::InMemory(node_id) => self.collect_nodes_for_commit_cached::<DB>(
+                        node_id,
+                        child_path,
+                        hashes,
+                        nodes_to_serialize,
+                    )?,
                 };
                 let hash = hashes.next().expect("mismatched hash state");
 
@@ -945,10 +1021,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 persisted_edge.hash = Some(hash);
                 persisted_edge.child = NodeHandle::Hash(child_hash);
                 let key_bytes: ByteVec = path.into();
-                updates.insert(
-                    TrieKey::new(&self.identifier, TrieKeyType::Trie, &key_bytes),
-                    InsertOrRemove::Insert(Node::Edge(persisted_edge).encode_bytevec()),
-                );
+                nodes_to_serialize.push((key_bytes, Node::Edge(persisted_edge)));
                 Ok(hash)
             }
         }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -1040,7 +1040,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         value: Felt,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
         let key_bytes = bitslice_to_bytes(key);
-        self.set_with_key_bytes(db, key, key_bytes, value)
+        self.set_with_key_bytes(db, key, key_bytes, value, true)
     }
 
     pub fn set_owned<DB: BonsaiDatabase, ID: Id>(
@@ -1050,7 +1050,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         value: Felt,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
         let key_bytes = bitvec_to_bytes(&key);
-        self.set_with_key_bytes(db, &key, key_bytes, value)
+        self.set_with_key_bytes(db, &key, key_bytes, value, true)
     }
 
     pub fn set_many_owned<DB, ID, I>(
@@ -1065,7 +1065,24 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     {
         for (key, value) in entries {
             let key_bytes = bitvec_to_bytes(&key);
-            self.set_with_key_bytes(db, &key, key_bytes, value)?;
+            self.set_with_key_bytes(db, &key, key_bytes, value, true)?;
+        }
+        Ok(())
+    }
+
+    pub fn set_many_owned_assume_changed<DB, ID, I>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        entries: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        DB: BonsaiDatabase,
+        ID: Id,
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        for (key, value) in entries {
+            let key_bytes = bitvec_to_bytes(&key);
+            self.set_with_key_bytes(db, &key, key_bytes, value, false)?;
         }
         Ok(())
     }
@@ -1076,6 +1093,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         key: &BitSlice,
         key_bytes: ByteVec,
         value: Felt,
+        check_committed_value: bool,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
         if value == Felt::ZERO {
             return self.delete_leaf(db, key);
@@ -1093,7 +1111,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             None => false,
         };
 
-        if !has_staged_override {
+        if check_committed_value && !has_staged_override {
             if let Some(value_db) = db.get(&TrieKey::new(
                 &self.identifier,
                 TrieKeyType::Flat,

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -953,16 +953,6 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         let key_bytes = bitslice_to_bytes(key);
         log::trace!("key_bytes: {:?}", key_bytes);
 
-        // TODO(perf): do not double lookup when changing the value later (borrow needs to be split for preload_nodes though)
-        let mut cache_leaf_entry = self.cache_leaf_modified.entry_ref(&key_bytes[..]);
-
-        if let hash_map::EntryRef::Occupied(entry) = &mut cache_leaf_entry {
-            if matches!(entry.get(), InsertOrRemove::Insert(_)) {
-                entry.insert(InsertOrRemove::Insert(value));
-                return Ok(());
-            }
-        }
-
         if let Some(value_db) = db.get(&TrieKey::new(
             &self.identifier,
             TrieKeyType::Flat,
@@ -1622,5 +1612,46 @@ mod staged_hash_cache_tests {
             "retained frontier should stay small for a single recently touched branch, got {} nodes",
             tree.nodes.len()
         );
+    }
+
+    #[test]
+    fn duplicate_staged_insert_invalidates_cached_root() {
+        let identifier = vec![];
+        let key = BitVec::from_vec(vec![0b1000_0000]);
+        let value_one = Felt::from_hex("0x11").unwrap();
+        let value_two = Felt::from_hex("0x22").unwrap();
+
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        bonsai_storage
+            .insert(&identifier, &key, &value_one)
+            .unwrap();
+        let staged_root = bonsai_storage.root_hash_staged(&identifier).unwrap();
+
+        bonsai_storage
+            .insert(&identifier, &key, &value_two)
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+        let committed_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+        let mut comparison_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut comparison_ids = BasicIdBuilder::new();
+        comparison_storage
+            .insert(&identifier, &key, &value_two)
+            .unwrap();
+        comparison_storage.commit(comparison_ids.new_id()).unwrap();
+        let expected_root = comparison_storage.root_hash(&identifier).unwrap();
+
+        assert_ne!(staged_root, expected_root);
+        assert_eq!(committed_root, expected_root);
     }
 }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -952,14 +952,21 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         }
         let key_bytes = bitslice_to_bytes(key);
         log::trace!("key_bytes: {:?}", key_bytes);
+        let has_staged_override = match self.cache_leaf_modified.get(&key_bytes) {
+            Some(InsertOrRemove::Insert(staged_value)) if *staged_value == value => return Ok(()),
+            Some(_) => true,
+            None => false,
+        };
 
-        if let Some(value_db) = db.get(&TrieKey::new(
-            &self.identifier,
-            TrieKeyType::Flat,
-            &key_bytes,
-        ))? {
-            if value == Felt::decode(&mut value_db.as_slice()).unwrap() {
-                return Ok(());
+        if !has_staged_override {
+            if let Some(value_db) = db.get(&TrieKey::new(
+                &self.identifier,
+                TrieKeyType::Flat,
+                &key_bytes,
+            ))? {
+                if value == Felt::decode(&mut value_db.as_slice()).unwrap() {
+                    return Ok(());
+                }
             }
         }
 
@@ -1653,5 +1660,39 @@ mod staged_hash_cache_tests {
 
         assert_ne!(staged_root, expected_root);
         assert_eq!(committed_root, expected_root);
+    }
+
+    #[test]
+    fn restoring_committed_value_overrides_staged_mutation() {
+        let identifier = vec![];
+        let key = BitVec::from_vec(vec![0b1000_0000]);
+        let committed_value = Felt::from_hex("0x11").unwrap();
+        let transient_value = Felt::from_hex("0x22").unwrap();
+
+        let mut bonsai_storage: BonsaiStorage<_, _, Pedersen> = BonsaiStorage::new(
+            HashMapDb::<BasicId>::default(),
+            BonsaiStorageConfig::default(),
+            8,
+        );
+        let mut id_builder = BasicIdBuilder::new();
+
+        bonsai_storage
+            .insert(&identifier, &key, &committed_value)
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+        let original_root = bonsai_storage.root_hash(&identifier).unwrap();
+
+        bonsai_storage
+            .insert(&identifier, &key, &transient_value)
+            .unwrap();
+        bonsai_storage
+            .insert(&identifier, &key, &committed_value)
+            .unwrap();
+        bonsai_storage.commit(id_builder.new_id()).unwrap();
+
+        assert_eq!(
+            bonsai_storage.root_hash(&identifier).unwrap(),
+            original_root
+        );
     }
 }

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -781,6 +781,10 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         path: Path,
         hashes: &mut Vec<Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        if let Some(hash) = node.get_hash() {
+            return Ok(hash);
+        }
+
         use Node::*;
 
         match node {
@@ -876,6 +880,10 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         path: Path,
         hashes: &mut impl Iterator<Item = Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
+        if let Some(hash) = self.nodes.get(node_id).and_then(Node::get_hash) {
+            return Ok(hash);
+        }
+
         match self
             .nodes
             .get(node_id)

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -7,8 +7,8 @@ use starknet_types_core::{felt::Felt, hash::StarkHash};
 use crate::trie::merkle_node::{hash_binary_node, hash_edge_node};
 use crate::BitVec;
 use crate::{
-    error::BonsaiStorageError, format, hash_map, id::Id, vec, BitSlice, BonsaiDatabase, ByteVec,
-    EncodeExt, HashMap, HashSet, KeyValueDB, ToString, Vec,
+    error::BonsaiStorageError, format, hash_map, id::Id, vec, BitSlice, BonsaiDatabase,
+    BulkInsertStats, ByteVec, EncodeExt, HashMap, HashSet, KeyValueDB, ToString, Vec,
 };
 
 use super::iterator::{MerkleTreeIterator, NodeVisitor};
@@ -1074,7 +1074,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             return Ok(());
         }
 
-        let entries = Self::prepare_nonzero_bulk_entries::<DB>(self.max_height, entries)?;
+        let (entries, _) = Self::prepare_nonzero_bulk_entries::<DB>(self.max_height, entries)?;
         let mut iter = self.iter(db);
         for (key, key_bytes, value) in entries {
             Self::set_nonzero_with_key_bytes_using_iter(&mut iter, &key, key_bytes, value, true)?;
@@ -1101,14 +1101,56 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             return Ok(());
         }
 
-        let entries = Self::prepare_nonzero_bulk_entries::<DB>(self.max_height, entries)?;
-        self.set_many_nonzero_owned_assume_changed_bulk(db, &entries)
+        self.set_many_owned_assume_changed_with_stats(db, entries)
+            .map(|_| ())
+    }
+
+    pub fn set_many_owned_assume_changed_with_stats<DB, ID, I>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        entries: I,
+    ) -> Result<BulkInsertStats, BonsaiStorageError<DB::DatabaseError>>
+    where
+        DB: BonsaiDatabase,
+        ID: Id,
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        if entries.iter().any(|(_, value)| *value == Felt::ZERO) {
+            let mut stats = BulkInsertStats {
+                input_entries: entries.len() as u64,
+                prepared_entries: entries.len() as u64,
+                max_range_entries: entries.len() as u64,
+                ..Default::default()
+            };
+            let db_loads_before = self.perf_stats.db_node_loads;
+            let memory_hits_before = self.perf_stats.in_memory_node_hits;
+            for (key, value) in entries {
+                let key_bytes = bitvec_to_bytes(&key);
+                self.set_with_key_bytes(db, &key, key_bytes, value, false)?;
+            }
+            stats.db_node_loads = self
+                .perf_stats
+                .db_node_loads
+                .saturating_sub(db_loads_before) as u64;
+            stats.in_memory_node_hits = self
+                .perf_stats
+                .in_memory_node_hits
+                .saturating_sub(memory_hits_before) as u64;
+            return Ok(stats);
+        }
+
+        let (entries, mut stats) =
+            Self::prepare_nonzero_bulk_entries::<DB>(self.max_height, entries)?;
+        self.set_many_nonzero_owned_assume_changed_bulk(db, &entries, &mut stats)?;
+        Ok(stats)
     }
 
     fn prepare_nonzero_bulk_entries<DB: BonsaiDatabase>(
         max_height: u8,
         entries: Vec<(BitVec, Felt)>,
-    ) -> Result<Vec<BulkEntry>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<(Vec<BulkEntry>, BulkInsertStats), BonsaiStorageError<DB::DatabaseError>> {
+        let input_entries = entries.len();
         let mut prepared = Vec::with_capacity(entries.len());
         for (position, (key, value)) in entries.into_iter().enumerate() {
             if key.len() != usize::from(max_height) {
@@ -1135,26 +1177,41 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             deduped.push((key, key_bytes, value));
         }
 
-        Ok(deduped)
+        let stats = BulkInsertStats {
+            input_entries: input_entries as u64,
+            prepared_entries: deduped.len() as u64,
+            duplicate_entries: input_entries.saturating_sub(deduped.len()) as u64,
+            max_range_entries: deduped.len() as u64,
+            ..Default::default()
+        };
+
+        Ok((deduped, stats))
     }
 
     fn set_many_nonzero_owned_assume_changed_bulk<DB: BonsaiDatabase, ID: Id>(
         &mut self,
         db: &KeyValueDB<DB, ID>,
         entries: &[BulkEntry],
+        stats: &mut BulkInsertStats,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
         if entries.is_empty() {
             return Ok(());
         }
 
+        let db_loads_before = self.perf_stats.db_node_loads;
+        let memory_hits_before = self.perf_stats.in_memory_node_hits;
         self.mark_dirty();
-        match self.load_root_node(db)? {
+        let result = match self.load_root_node(db)? {
             Some(root_id) => {
-                self.bulk_update_node_assume_changed(db, root_id, &Path::default(), entries)
+                self.bulk_update_node_assume_changed(db, root_id, &Path::default(), entries, stats)
             }
             None => {
-                let root =
-                    self.bulk_build_handle_assume_changed::<DB>(&Path::default(), entries)?;
+                let root = self.bulk_build_handle_assume_changed::<DB>(
+                    &Path::default(),
+                    entries,
+                    0,
+                    stats,
+                )?;
                 match root {
                     NodeHandle::InMemory(root_id) => {
                         self.root_node = Some(RootHandle::Loaded(root_id));
@@ -1165,7 +1222,16 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                     )),
                 }
             }
-        }
+        };
+        stats.db_node_loads = self
+            .perf_stats
+            .db_node_loads
+            .saturating_sub(db_loads_before) as u64;
+        stats.in_memory_node_hits = self
+            .perf_stats
+            .in_memory_node_hits
+            .saturating_sub(memory_hits_before) as u64;
+        result
     }
 
     fn bulk_update_handle_assume_changed<DB: BonsaiDatabase, ID: Id>(
@@ -1174,10 +1240,12 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         handle: NodeHandle,
         prefix: &Path,
         entries: &[BulkEntry],
+        stats: &mut BulkInsertStats,
     ) -> Result<NodeHandle, BonsaiStorageError<DB::DatabaseError>> {
         if entries.is_empty() {
             return Ok(handle);
         }
+        stats.max_range_entries = stats.max_range_entries.max(entries.len() as u64);
 
         if prefix.len() == usize::from(self.max_height) {
             let (_key, key_bytes, value) = entries
@@ -1185,11 +1253,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 .expect("bulk update handle called with non-empty entries");
             self.cache_leaf_modified
                 .insert(key_bytes.clone(), InsertOrRemove::Insert(*value));
+            stats.leaf_updates += 1;
             return Ok(NodeHandle::Hash(*value));
         }
 
+        stats.loaded_handles += 1;
         let node_id = self.load_node_handle(db, handle, prefix)?;
-        self.bulk_update_node_assume_changed(db, node_id, prefix, entries)?;
+        self.bulk_update_node_assume_changed(db, node_id, prefix, entries, stats)?;
         Ok(NodeHandle::InMemory(node_id))
     }
 
@@ -1199,10 +1269,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         node_id: NodeKey,
         prefix: &Path,
         entries: &[BulkEntry],
+        stats: &mut BulkInsertStats,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        stats.max_range_entries = stats.max_range_entries.max(entries.len() as u64);
         let node = self.get_node_mut::<DB>(node_id)?.clone();
         match node {
             Node::Binary(mut binary) => {
+                stats.updated_binary_nodes += 1;
                 let height = binary.height as usize;
                 debug_assert_eq!(height, prefix.len());
                 binary.hash = None;
@@ -1216,6 +1289,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                         binary.left,
                         &left_prefix,
                         &entries[..split],
+                        stats,
                     )?;
                 }
                 if split < entries.len() {
@@ -1226,12 +1300,14 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                         binary.right,
                         &right_prefix,
                         &entries[split..],
+                        stats,
                     )?;
                 }
 
                 self.nodes[node_id] = Node::Binary(binary);
             }
             Node::Edge(mut edge) => {
+                stats.updated_edge_nodes += 1;
                 let height = edge.height as usize;
                 debug_assert_eq!(height, prefix.len());
                 edge.hash = None;
@@ -1245,11 +1321,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                         edge.child,
                         &child_prefix,
                         entries,
+                        stats,
                     )?;
                     self.nodes[node_id] = Node::Edge(edge);
                     return Ok(());
                 }
 
+                stats.split_edge_nodes += 1;
                 let branch_height = height + common_len;
                 let child_height = branch_height + 1;
                 let common_path = edge.path[..common_len].to_bitvec();
@@ -1269,6 +1347,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                         path: Path(old_path),
                         child: edge.child,
                     }));
+                    stats.built_edge_nodes += 1;
                     NodeHandle::InMemory(edge_id)
                 };
 
@@ -1288,6 +1367,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                                 old_handle,
                                 &old_prefix,
                                 left_entries,
+                                stats,
                             )?
                         });
                     }
@@ -1300,6 +1380,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                                 old_handle,
                                 &old_prefix,
                                 right_entries,
+                                stats,
                             )?
                         });
                     }
@@ -1309,17 +1390,23 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                     let mut left_prefix = prefix.clone();
                     left_prefix.extend_from_bitslice(&common_path);
                     left_prefix.push(false);
-                    left_handle = Some(
-                        self.bulk_build_handle_assume_changed::<DB>(&left_prefix, left_entries)?,
-                    );
+                    left_handle = Some(self.bulk_build_handle_assume_changed::<DB>(
+                        &left_prefix,
+                        left_entries,
+                        0,
+                        stats,
+                    )?);
                 }
                 if right_handle.is_none() && !right_entries.is_empty() {
                     let mut right_prefix = prefix.clone();
                     right_prefix.extend_from_bitslice(&common_path);
                     right_prefix.push(true);
-                    right_handle = Some(
-                        self.bulk_build_handle_assume_changed::<DB>(&right_prefix, right_entries)?,
-                    );
+                    right_handle = Some(self.bulk_build_handle_assume_changed::<DB>(
+                        &right_prefix,
+                        right_entries,
+                        0,
+                        stats,
+                    )?);
                 }
 
                 let branch = Node::Binary(BinaryNode {
@@ -1334,9 +1421,12 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 });
 
                 self.nodes[node_id] = if common_path.is_empty() {
+                    stats.built_binary_nodes += 1;
                     branch
                 } else {
                     let branch_id = self.nodes.insert(branch);
+                    stats.built_binary_nodes += 1;
+                    stats.built_edge_nodes += 1;
                     Node::Edge(EdgeNode {
                         hash: None,
                         height: height as u64,
@@ -1354,12 +1444,16 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         &mut self,
         prefix: &Path,
         entries: &[BulkEntry],
+        depth: u64,
+        stats: &mut BulkInsertStats,
     ) -> Result<NodeHandle, BonsaiStorageError<DB::DatabaseError>> {
         if entries.is_empty() {
             return Err(BonsaiStorageError::Trie(
                 "bulk build called with no entries".to_string(),
             ));
         }
+        stats.max_range_entries = stats.max_range_entries.max(entries.len() as u64);
+        stats.max_build_depth = stats.max_build_depth.max(depth);
 
         if entries.len() == 1 || prefix.len() == usize::from(self.max_height) {
             let (key, key_bytes, value) = entries
@@ -1367,6 +1461,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 .expect("bulk build called with non-empty entries");
             self.cache_leaf_modified
                 .insert(key_bytes.clone(), InsertOrRemove::Insert(*value));
+            stats.leaf_updates += 1;
 
             if prefix.len() == usize::from(self.max_height) {
                 return Ok(NodeHandle::Hash(*value));
@@ -1378,6 +1473,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 path: Path(key[prefix.len()..].to_bitvec()),
                 child: NodeHandle::Hash(*value),
             }));
+            stats.built_edge_nodes += 1;
             return Ok(NodeHandle::InMemory(edge_id));
         }
 
@@ -1385,13 +1481,19 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         if shared_prefix_len > prefix.len() {
             let mut child_prefix = prefix.clone();
             child_prefix.extend_from_bitslice(&entries[0].0[prefix.len()..shared_prefix_len]);
-            let child = self.bulk_build_handle_assume_changed::<DB>(&child_prefix, entries)?;
+            let child = self.bulk_build_handle_assume_changed::<DB>(
+                &child_prefix,
+                entries,
+                depth + 1,
+                stats,
+            )?;
             let edge_id = self.nodes.insert(Node::Edge(EdgeNode {
                 hash: None,
                 height: prefix.len() as u64,
                 path: Path(entries[0].0[prefix.len()..shared_prefix_len].to_bitvec()),
                 child,
             }));
+            stats.built_edge_nodes += 1;
             return Ok(NodeHandle::InMemory(edge_id));
         }
 
@@ -1404,12 +1506,21 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
 
         let mut left_prefix = prefix.clone();
         left_prefix.push(false);
-        let left = self.bulk_build_handle_assume_changed::<DB>(&left_prefix, &entries[..split])?;
+        let left = self.bulk_build_handle_assume_changed::<DB>(
+            &left_prefix,
+            &entries[..split],
+            depth + 1,
+            stats,
+        )?;
 
         let mut right_prefix = prefix.clone();
         right_prefix.push(true);
-        let right =
-            self.bulk_build_handle_assume_changed::<DB>(&right_prefix, &entries[split..])?;
+        let right = self.bulk_build_handle_assume_changed::<DB>(
+            &right_prefix,
+            &entries[split..],
+            depth + 1,
+            stats,
+        )?;
 
         let binary_id = self.nodes.insert(Node::Binary(BinaryNode {
             hash: None,
@@ -1417,6 +1528,7 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
             left,
             right,
         }));
+        stats.built_binary_nodes += 1;
         Ok(NodeHandle::InMemory(binary_id))
     }
 

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -1039,6 +1039,27 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         key: &BitSlice,
         value: Felt,
     ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let key_bytes = bitslice_to_bytes(key);
+        self.set_with_key_bytes(db, key, key_bytes, value)
+    }
+
+    pub fn set_owned<DB: BonsaiDatabase, ID: Id>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        key: BitVec,
+        value: Felt,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let key_bytes = bitvec_to_bytes(&key);
+        self.set_with_key_bytes(db, &key, key_bytes, value)
+    }
+
+    fn set_with_key_bytes<DB: BonsaiDatabase, ID: Id>(
+        &mut self,
+        db: &KeyValueDB<DB, ID>,
+        key: &BitSlice,
+        key_bytes: ByteVec,
+        value: Felt,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
         if value == Felt::ZERO {
             return self.delete_leaf(db, key);
         }
@@ -1048,7 +1069,6 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                 got: key.len(),
             });
         }
-        let key_bytes = bitslice_to_bytes(key);
         log::trace!("key_bytes: {:?}", key_bytes);
         let has_staged_override = match self.cache_leaf_modified.get(&key_bytes) {
             Some(InsertOrRemove::Insert(staged_value)) if *staged_value == value => return Ok(()),
@@ -1594,6 +1614,15 @@ pub(crate) fn bitslice_to_bytes(bitslice: &BitSlice) -> ByteVec {
     } // special case: tree root
     iter::once(bitslice.len() as u8)
         .chain(bitslice.to_bitvec().as_raw_slice().iter().copied())
+        .collect()
+}
+
+fn bitvec_to_bytes(bitvec: &BitVec) -> ByteVec {
+    if bitvec.is_empty() {
+        return Default::default();
+    }
+    iter::once(bitvec.len() as u8)
+        .chain(bitvec.as_raw_slice().iter().copied())
         .collect()
 }
 

--- a/src/trie/tree.rs
+++ b/src/trie/tree.rs
@@ -411,7 +411,8 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
     #[allow(clippy::type_complexity)]
     pub(crate) fn get_updates<DB: BonsaiDatabase>(
         &mut self,
-    ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>> {
+    ) -> Result<HashMap<TrieKey, InsertOrRemove<ByteVec>>, BonsaiStorageError<DB::DatabaseError>>
+    {
         let dirty_before_commit = self.dirty;
         let mut updates = HashMap::new();
         for node_key in mem::take(&mut self.death_row) {
@@ -549,7 +550,8 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
                     self.perf_stats.db_node_loads,
                     self.perf_stats.in_memory_node_hits,
                 );
-                self.staged_hashes.store(StagedHashComputation { root_hash, hashes });
+                self.staged_hashes
+                    .store(StagedHashComputation { root_hash, hashes });
                 Ok(root_hash)
             }
             Some(RootHandle::Empty) => Ok(Felt::ZERO),
@@ -682,9 +684,13 @@ impl<H: StarkHash + Send + Sync> MerkleTree<H> {
         path: Path,
         hashes: &mut impl Iterator<Item = Felt>,
     ) -> Result<Felt, BonsaiStorageError<DB::DatabaseError>> {
-        match self.nodes.get(node_id).cloned().ok_or(BonsaiStorageError::Trie(
-            "Couldn't fetch node in the temporary storage".to_string(),
-        ))? {
+        match self
+            .nodes
+            .get(node_id)
+            .cloned()
+            .ok_or(BonsaiStorageError::Trie(
+                "Couldn't fetch node in the temporary storage".to_string(),
+            ))? {
             Node::Binary(binary) => {
                 let left_path = path.new_with_direction(Direction::Left);
                 let left_hash = match binary.left {

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -73,6 +73,22 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
         tree.set_owned(&self.db, key, value)
     }
 
+    pub(crate) fn set_many_owned<I>(
+        &mut self,
+        identifier: &[u8],
+        entries: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        let tree = self
+            .trees
+            .entry_ref(identifier)
+            .or_insert_with(|| MerkleTree::new(identifier.into(), self.max_height));
+
+        tree.set_many_owned(&self.db, entries)
+    }
+
     pub(crate) fn get(
         &self,
         identifier: &[u8],

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -1,7 +1,7 @@
 use super::{proof::MultiProof, tree::MerkleTree};
 use crate::{
     id::Id, key_value_db::KeyValueDB, trie::tree::InsertOrRemove, BitSlice, BitVec, BonsaiDatabase,
-    BonsaiStorageError, ByteVec, HashMap, Vec,
+    BonsaiStorageError, BulkInsertStats, ByteVec, HashMap, Vec,
 };
 use core::fmt;
 use starknet_types_core::{felt::Felt, hash::StarkHash};
@@ -103,6 +103,22 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
             .or_insert_with(|| MerkleTree::new(identifier.into(), self.max_height));
 
         tree.set_many_owned_assume_changed(&self.db, entries)
+    }
+
+    pub(crate) fn set_many_owned_assume_changed_with_stats<I>(
+        &mut self,
+        identifier: &[u8],
+        entries: I,
+    ) -> Result<BulkInsertStats, BonsaiStorageError<DB::DatabaseError>>
+    where
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        let tree = self
+            .trees
+            .entry_ref(identifier)
+            .or_insert_with(|| MerkleTree::new(identifier.into(), self.max_height));
+
+        tree.set_many_owned_assume_changed_with_stats(&self.db, entries)
     }
 
     pub(crate) fn get(

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -105,6 +105,61 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
         tree.set_many_owned_assume_changed(&self.db, entries)
     }
 
+    pub(crate) fn set_many_by_identifier_owned_assume_changed<I, E>(
+        &mut self,
+        updates: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        DB: Sync,
+        CommitID: Sync,
+        I: IntoIterator<Item = (ByteVec, E)>,
+        E: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        let mut updates_by_identifier: HashMap<ByteVec, Vec<(BitVec, Felt)>> = HashMap::new();
+        for (identifier, entries) in updates {
+            updates_by_identifier
+                .entry(identifier)
+                .or_default()
+                .extend(entries);
+        }
+
+        for identifier in updates_by_identifier.keys() {
+            self.trees
+                .entry_ref(identifier.as_slice())
+                .or_insert_with(|| MerkleTree::new(identifier.clone(), self.max_height));
+        }
+
+        #[cfg(feature = "std")]
+        {
+            use rayon::prelude::*;
+
+            self.trees
+                .par_iter_mut()
+                .filter_map(|(identifier, tree)| {
+                    updates_by_identifier
+                        .get(identifier)
+                        .map(|entries| (tree, entries))
+                })
+                .map(|(tree, entries)| {
+                    tree.set_many_owned_assume_changed(&self.db, entries.iter().cloned())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            for (identifier, entries) in updates_by_identifier {
+                let tree = self
+                    .trees
+                    .get_mut(identifier.as_slice())
+                    .expect("tree was inserted before applying updates");
+                tree.set_many_owned_assume_changed(&self.db, entries)?;
+            }
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn get(
         &self,
         identifier: &[u8],

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -105,61 +105,6 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
         tree.set_many_owned_assume_changed(&self.db, entries)
     }
 
-    pub(crate) fn set_many_by_identifier_owned_assume_changed<I, E>(
-        &mut self,
-        updates: I,
-    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
-    where
-        DB: Sync,
-        CommitID: Sync,
-        I: IntoIterator<Item = (ByteVec, E)>,
-        E: IntoIterator<Item = (BitVec, Felt)>,
-    {
-        let mut updates_by_identifier: HashMap<ByteVec, Vec<(BitVec, Felt)>> = HashMap::new();
-        for (identifier, entries) in updates {
-            updates_by_identifier
-                .entry(identifier)
-                .or_default()
-                .extend(entries);
-        }
-
-        for identifier in updates_by_identifier.keys() {
-            self.trees
-                .entry_ref(identifier.as_slice())
-                .or_insert_with(|| MerkleTree::new(identifier.clone(), self.max_height));
-        }
-
-        #[cfg(feature = "std")]
-        {
-            use rayon::prelude::*;
-
-            self.trees
-                .par_iter_mut()
-                .filter_map(|(identifier, tree)| {
-                    updates_by_identifier
-                        .get(identifier)
-                        .map(|entries| (tree, entries))
-                })
-                .map(|(tree, entries)| {
-                    tree.set_many_owned_assume_changed(&self.db, entries.iter().cloned())
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-        }
-
-        #[cfg(not(feature = "std"))]
-        {
-            for (identifier, entries) in updates_by_identifier {
-                let tree = self
-                    .trees
-                    .get_mut(identifier.as_slice())
-                    .expect("tree was inserted before applying updates");
-                tree.set_many_owned_assume_changed(&self.db, entries)?;
-            }
-        }
-
-        Ok(())
-    }
-
     pub(crate) fn get(
         &self,
         identifier: &[u8],

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -208,13 +208,11 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
             .trees
             .par_iter_mut()
             .map(|(_, tree)| tree.get_updates::<DB>())
-            .collect_vec_list()
-            .into_iter()
-            .flatten();
+            .collect::<Vec<_>>();
 
         let mut batch = self.db.create_batch();
         for changes in db_changes {
-            for (key, value) in changes? {
+            for (key, value) in changes?.into_iter() {
                 match value {
                     InsertOrRemove::Insert(value) => {
                         self.db.insert(&key, &value, Some(&mut batch))?;

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -198,6 +198,9 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
         #[cfg(feature = "std")]
         use rayon::prelude::*;
 
+        #[cfg(feature = "std")]
+        let get_updates_start = std::time::Instant::now();
+
         #[cfg(not(feature = "std"))]
         let db_changes = self
             .trees
@@ -210,12 +213,24 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
             .map(|(_, tree)| tree.get_updates::<DB>())
             .collect::<Vec<_>>();
 
+        #[cfg(feature = "std")]
+        let get_updates_duration = get_updates_start.elapsed();
+
         let track_changes = self.db.get_config().max_saved_trie_logs != Some(0);
+        #[cfg(feature = "std")]
+        let batch_prepare_start = std::time::Instant::now();
+
         let mut batch = self.db.create_batch();
+        let mut total_updates = 0usize;
+        let mut insert_updates = 0usize;
+        let mut remove_updates = 0usize;
         for changes in db_changes {
-            for (key, value) in changes?.into_iter() {
+            let changes = changes?;
+            total_updates += changes.len();
+            for (key, value) in changes.into_iter() {
                 match value {
                     InsertOrRemove::Insert(value) => {
+                        insert_updates += 1;
                         if track_changes {
                             self.db.insert(&key, &value, Some(&mut batch))?;
                         } else {
@@ -223,6 +238,7 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
                         }
                     }
                     InsertOrRemove::Remove => {
+                        remove_updates += 1;
                         if track_changes {
                             self.db.remove(&key, Some(&mut batch))?;
                         } else {
@@ -232,7 +248,26 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
                 }
             }
         }
+
+        #[cfg(feature = "std")]
+        let batch_prepare_duration = batch_prepare_start.elapsed();
+        #[cfg(feature = "std")]
+        let write_batch_start = std::time::Instant::now();
+
         self.db.write_batch(batch)?;
+
+        #[cfg(feature = "std")]
+        log::info!(
+            "bonsai merkle_trees commit timings trees={} updates={} inserts={} removes={} track_changes={} get_updates_ms={:.3} batch_prepare_ms={:.3} write_batch_ms={:.3}",
+            self.trees.len(),
+            total_updates,
+            insert_updates,
+            remove_updates,
+            track_changes,
+            get_updates_duration.as_secs_f64() * 1000.0,
+            batch_prepare_duration.as_secs_f64() * 1000.0,
+            write_batch_start.elapsed().as_secs_f64() * 1000.0,
+        );
         Ok(())
     }
 

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -210,15 +210,24 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
             .map(|(_, tree)| tree.get_updates::<DB>())
             .collect::<Vec<_>>();
 
+        let track_changes = self.db.get_config().max_saved_trie_logs != Some(0);
         let mut batch = self.db.create_batch();
         for changes in db_changes {
             for (key, value) in changes?.into_iter() {
                 match value {
                     InsertOrRemove::Insert(value) => {
-                        self.db.insert(&key, &value, Some(&mut batch))?;
+                        if track_changes {
+                            self.db.insert(&key, &value, Some(&mut batch))?;
+                        } else {
+                            self.db.insert_untracked(&key, &value, &mut batch)?;
+                        }
                     }
                     InsertOrRemove::Remove => {
-                        self.db.remove(&key, Some(&mut batch))?;
+                        if track_changes {
+                            self.db.remove(&key, Some(&mut batch))?;
+                        } else {
+                            self.db.remove_untracked(&key, &mut batch)?;
+                        }
                     }
                 }
             }

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -1,6 +1,6 @@
 use super::{proof::MultiProof, tree::MerkleTree};
 use crate::{
-    id::Id, key_value_db::KeyValueDB, trie::tree::InsertOrRemove, BitSlice, BonsaiDatabase,
+    id::Id, key_value_db::KeyValueDB, trie::tree::InsertOrRemove, BitSlice, BitVec, BonsaiDatabase,
     BonsaiStorageError, ByteVec, HashMap, Vec,
 };
 use core::fmt;
@@ -57,6 +57,20 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
             .or_insert_with(|| MerkleTree::new(identifier.into(), self.max_height));
 
         tree.set(&self.db, key, value)
+    }
+
+    pub(crate) fn set_owned(
+        &mut self,
+        identifier: &[u8],
+        key: BitVec,
+        value: Felt,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>> {
+        let tree = self
+            .trees
+            .entry_ref(identifier)
+            .or_insert_with(|| MerkleTree::new(identifier.into(), self.max_height));
+
+        tree.set_owned(&self.db, key, value)
     }
 
     pub(crate) fn get(

--- a/src/trie/trees.rs
+++ b/src/trie/trees.rs
@@ -89,6 +89,22 @@ impl<H: StarkHash + Send + Sync, DB: BonsaiDatabase, CommitID: Id> MerkleTrees<H
         tree.set_many_owned(&self.db, entries)
     }
 
+    pub(crate) fn set_many_owned_assume_changed<I>(
+        &mut self,
+        identifier: &[u8],
+        entries: I,
+    ) -> Result<(), BonsaiStorageError<DB::DatabaseError>>
+    where
+        I: IntoIterator<Item = (BitVec, Felt)>,
+    {
+        let tree = self
+            .trees
+            .entry_ref(identifier)
+            .or_insert_with(|| MerkleTree::new(identifier.into(), self.max_height));
+
+        tree.set_many_owned_assume_changed(&self.db, entries)
+    }
+
     pub(crate) fn get(
         &self,
         identifier: &[u8],


### PR DESCRIPTION
## Summary
- add an owned-bitvec insert path to avoid a second bit-vector allocation while encoding flat trie keys
- keep existing trie traversal semantics unchanged
- add equivalence coverage against regular insert for Starknet-style keys

## Validation
- cargo test